### PR TITLE
bugfix/get_discrete_sensor_reading

### DIFF
--- a/infrasim/ipmicons/command.py
+++ b/infrasim/ipmicons/command.py
@@ -7,6 +7,7 @@ from .common import logger, msg_queue
 from .sdr import sensor_id_map
 from .sel import SEL
 
+import common
 import re
 
 
@@ -135,6 +136,12 @@ class Command_Handler:
 
     # ######### SET SENSOR VALUE FUNCTION ##########
     def set_sensor_value(self, args):
+        """
+        Set sensor value to sensor object, and then write back to
+        openipmi data structure.
+        :param args:
+            - <sensor id>, <sensor value>: set value to the id
+        """
         if len(args) != 2:
             msg_queue.put(self.handle_sensor_value.__doc__+'\n')
             return
@@ -180,6 +187,11 @@ class Command_Handler:
 
     # ######### GET SENSOR VALUE FUNCTION ##########
     def get_sensor_value(self, args):
+        """
+        Get sensor value from sensor object, NOT from openipmi data
+        structure.
+        :param args: <sensor id>
+        """
         if len(args) != 1:
             msg_queue.put(self.handle_sensor_value.__doc__+'\n')
             return
@@ -189,14 +201,17 @@ class Command_Handler:
             return
 
         raw_value = sensor_obj.get_value()
-        value = hex(raw_value)
         if sensor_obj.get_event_type() == 'threshold':
             formula = sensor_obj.get_reading_factor()[0]
             value = '%.3f' % formula(raw_value)
-        info = "{0} : {1} {2}\n".format(sensor_obj.get_name(),
-                                        value, sensor_obj.get_unit())
-        self.add_msg(info)
-        msg_queue.put(info)
+            info = "{0} : {1} {2}\n".format(sensor_obj.get_name(),
+                                            value, sensor_obj.get_unit())
+            self.add_msg(info)
+            msg_queue.put(info)
+        elif sensor_obj.get_event_type() == 'discrete':
+            info = "{} : {}".format(sensor_obj.get_name(), raw_value)
+            self.add_msg(info)
+            msg_queue.put(info)
 
     # ######### SENSOR VALUE FUNCTIONS ##########
     def handle_sensor_value(self, args):

--- a/test/unit/test_ipmi_console_command.py
+++ b/test/unit/test_ipmi_console_command.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from infrasim.ipmicons import sdr
+from infrasim.ipmicons.command import Command_Handler
+from infrasim.ipmicons.common import msg_queue
+import unittest
+
+ch = Command_Handler()
+
+
+class test_ipmi_console(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def test_sensor_value_get_discrete(self):
+        sensor_d = sdr.build_sensors(name="discrete_sample", ID=0x10, value="0xca10", tp=0x00)
+        sensor_d.set_event_type(0x6f)
+
+        ch.get_sensor_value(["0x10"])
+        assert "0xca10" in msg_queue.get()
+
+    def test_sensor_value_get_analog(self):
+        sensor_a = sdr.build_sensors(name="analog_sample", ID=0x11, value=0x63, tp=0x00)
+        sensor_a.set_event_type(0x01)
+        sensor_a.set_m_lb(0x58)
+        sensor_a.set_m_ub(0x00)
+        sensor_a.set_b_lb(0x00)
+        sensor_a.set_b_ub(0x00)
+        sensor_a.set_exp(0x00)
+        sensor_a.set_su2(18)
+
+        ch.get_sensor_value(["0x11"])
+        assert "analog_sample : 8712.000 RPM" in msg_queue.get()


### PR DESCRIPTION
sdr.py
- For discrete sensor, parse last 2 bytes as sensor reading
and record in string, e.g. "0x1ac0"

command.py
- sensor value get <id> now returns value referring to event
type. If it's discrete sensor, it return two byte in little
endian.

Add unit test for get sensor value for both discrete and
analog sensor.
Local test pass.