### PR TITLE
Remove the 'Terminate' caution at the end of the test_ipmi_console.

### DIFF
--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -60,7 +60,7 @@ class test_ipmi_console(unittest.TestCase):
     def tearDownClass(cls):
         cls.channel.close()
         cls.ssh.close()
-        run_command('ipmi-console stop', True, None, None)
+        run_command('ipmi-console stop', True, subprocess.PIPE, subprocess.PIPE)
         qemu.stop_qemu()
         ipmi.stop_ipmi()
         socat.stop_socat()


### PR DESCRIPTION
@sharkconi local test passed.