### PR TITLE
bugfix/set_discrete_sensor_reading

### DIFF
--- a/infrasim/ipmicons/command.py
+++ b/infrasim/ipmicons/command.py
@@ -8,6 +8,7 @@ from .sdr import sensor_id_map
 from .sel import SEL
 
 import common
+import sel
 import re
 
 
@@ -141,11 +142,8 @@ class Command_Handler:
         openipmi data structure.
         :param args:
             - <sensor id>, <sensor value>: set value to the id
+            - <sensor id>, state, <state id>, 1|0: set state bit to 1 or 0
         """
-        if len(args) != 2:
-            msg_queue.put(self.handle_sensor_value.__doc__+'\n')
-            return
-
         sensor_obj = self.get_sensor_instance(args[0])
         if sensor_obj is None:
             return
@@ -157,33 +155,67 @@ class Command_Handler:
             sensor_obj.condition.notify()
             sensor_obj.condition.release()
 
-        if sensor_obj.get_event_type() == 'threshold':
-            try:
-                analog_value = float(args[1])
-            except:
-                error_info = 'illgel sensor value: {0}\n'.format(args[1])
-                msg_queue.put(error_info)
-                self.add_msg(error_info)
+        # <sensor id>, <sensor value>: set value to the id
+        if len(args) == 2:
+
+            if sensor_obj.get_event_type() == 'threshold':
+                try:
+                    analog_value = float(args[1])
+                except:
+                    error_info = 'illgel sensor value: {0}\n'.format(args[1])
+                    msg_queue.put(error_info)
+                    self.add_msg(error_info)
+                    return
+
+                formula = sensor_obj.get_reading_factor()[1]
+                raw_value = int(formula(analog_value))
+                info = 'sensor name: {0} formula: {1}. raw value: {2}\n'.\
+                    format(sensor_obj.get_name(), formula, raw_value)
+                logger.info(info)
+
+                sensor_obj.set_threshold_value(raw_value)
+
+            elif sensor_obj.get_event_type() == 'discrete':
+                # Parameters validation
+                try:
+                    int(args[1], 16)
+                except ValueError:
+                    msg_queue.put(self.handle_sensor_value.__doc__+'\n')
+                    return
+                if args[1].lower().startswith("0x") and len(args[1]) == 6:
+                    raw_value = args[1]
+                elif not args[1].lower().startswith("0x") and len(args[1]) == 4:
+                    raw_value = "0x"+args[1]
+                else:
+                    msg_queue.put(self.handle_sensor_value.__doc__+'\n')
+                    return
+                info = 'sensor name: {0} raw value: {1}\n'.\
+                    format(sensor_obj.get_name(), raw_value)
+                logger.info(info)
+
+                sensor_obj.set_discrete_value(raw_value)
+        # <sensor id>, state, <state id>, 1|0: set state bit to 1 or 0
+        elif len(args) == 4:
+            if sensor_obj.get_event_type() != 'discrete':
+                info = 'Set state bit is for discrete sensor only, sensor: {} is {}'.\
+                    format(args[0], sensor_obj.get_event_type())
+                msg_queue.put(info)
+                logger.info(info)
+                return
+            if args[1].lower() != 'state' \
+                    or int(args[2]) not in range(0, 15) \
+                    or args[3] not in ['1', '0']:
+                msg_queue.put(self.handle_sensor_value.__doc__+'\n')
                 return
 
-            formula = sensor_obj.get_reading_factor()[1]
-            raw_value = int(formula(analog_value))
-            info = 'sensor name: {0} formula: {1}. raw value: {2}\n'.format(
-                sensor_obj.get_name(), formula, raw_value)
-            logger.info(info)
+            # Set bit for discrete sensor
+            sensor_obj.set_state(int(args[2]), int(args[3]))
 
-            # switch to "user" mode if in "auto" mode
-            if sensor_obj.get_mode() == "auto":
-                sensor_obj.set_mode("user")
-                sensor_obj.condition.acquire()
-                sensor_obj.condition.notify()
-                sensor_obj.condition.release()
         else:
-            raw_value = common.str_hex_to_int(args[1])
-            if raw_value is None:
-                return
+            msg_queue.put(self.handle_sensor_value.__doc__+'\n')
+            return
 
-        sensor_obj.set_value(raw_value)
+
 
     # ######### GET SENSOR VALUE FUNCTION ##########
     def get_sensor_value(self, args):
@@ -218,6 +250,7 @@ class Command_Handler:
         """
         Available 'sensor value' commands:
             set: set <sensor id> <value>
+                 set <sensor id> state <state id> 1|0
             get: get <sensor id>
         """
         if len(args) == 0:

--- a/infrasim/ipmicons/common.py
+++ b/infrasim/ipmicons/common.py
@@ -86,7 +86,9 @@ def send_ipmi_sim_command(command):
         logger.info("IPMI SIM command result: " + result)
     except socket.error as se:
         logger.error("Unable to connect lanserv at 9000: {0}".format(se))
-    lock.release()
+    finally:
+        lock.release()
+
     return result
 
 

--- a/infrasim/ipmicons/sdr.py
+++ b/infrasim/ipmicons/sdr.py
@@ -35,7 +35,7 @@ def dump_all_sdrs(file_name):
 
 
 #  read sensor value via ipmitool
-def read_sensor_raw_value(sensor_num, event_type="analog"):
+def read_sensor_raw_value(sensor_num, event_type="threshold"):
     """
     Get sensor readying:
     - for analog sensor, return int
@@ -49,7 +49,7 @@ def read_sensor_raw_value(sensor_num, event_type="analog"):
                                           hex(sensor_num))
     if result == -1:
         return 0
-    if event_type == "analog":
+    if event_type == "threshold":
         value = result.split()[0]
         info = "sensor num: {0} value: 0x{1}".format(hex(sensor_num), value)
         logger.info(info)
@@ -111,7 +111,7 @@ def parse_sdrs():
         if event_type == 0x0:
             sensor_value = None
         elif event_type == 0x1:
-            sensor_value = read_sensor_raw_value(sensor_num)
+            sensor_value = read_sensor_raw_value(sensor_num, 'threshold')
         else:
             sensor_value = read_sensor_raw_value(sensor_num, "discrete")
 


### PR DESCRIPTION
Now discrete sensor value can be set with:
- sensor value set \<sensor id\> \<sensor value\>

*<sensor value> must in HEX*

Now discrete sensor state can be set with:
- sensor value set \<sensor id\> state \<state id\> 0|1

*<state id> must be in 0-14, referring to IPMI 2.0*

sensor.py
- added decorator to constraints class Sensor's functions, some
functions are for discrete sensors only and some are for analog
sensors
- renamed set_threshold_value(), which is set_value() before
- added set_discrete_value()
- added set_state() to change certain state of a discrete sensor

command.py
- handle sensor value command to invoke certain value set
function