### PR TITLE
feature/enable_node_implementation

### DIFF
--- a/bin/infrasim-init
+++ b/bin/infrasim-init
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os, sys, jinja2, random, string
+import os
+import jinja2
+import random
+import string
 from infrasim import run_command, CommandNotFound
 from infrasim.socat import get_socat
 from infrasim.ipmi import get_ipmi
@@ -10,8 +13,6 @@ import netifaces
 
 INFRASIM_TEMP_CONF = "/usr/local/etc/infrasim/conf/infrasim.yml"
 INFRASIM_CONF = "/etc/infrasim/infrasim.yml"
-VBMC_TEMP_CONF = "/usr/local/etc/infrasim/conf/vbmc.conf"
-VBMC_CONF = "/etc/infrasim/vbmc.conf"
 
 mac_base = "00:60:16:"
 
@@ -54,12 +55,13 @@ def create_infrasim_directories():
         os.system("rm -rf /usr/local/libexec")
         os.mkdir("/usr/local/libexec")
 
+
 def create_infrasim_conf():
 
     # Prepare default network
     networks = []
     nics_list = netifaces.interfaces()
-    eth_nic = filter(lambda x: 'e' in x,nics_list)[0]
+    eth_nic = filter(lambda x: 'e' in x, nics_list)[0]
     mac = create_mac_address()
     networks.append({"nic": eth_nic, "mac": mac})
 
@@ -67,7 +69,7 @@ def create_infrasim_conf():
     disks = []
     disks.append({"size": 8})
 
-    # Render infrasim.conf
+    # Render infrasim.yml
     infrasim_conf = ""
     with open(INFRASIM_TEMP_CONF, "r") as f:
         infrasim_conf = f.read()
@@ -76,14 +78,6 @@ def create_infrasim_conf():
     with open(INFRASIM_CONF, "w") as f:
         f.write(infrasim_conf)
 
-    # Render vbmc.conf
-    vbmc_conf = ""
-    with open(VBMC_TEMP_CONF, "r") as f:
-        vbmc_conf = f.read()
-    template = jinja2.Template(vbmc_conf)
-    vbmc_conf = template.render(nic=eth_nic)
-    with open(VBMC_CONF, "w") as f:
-        f.write(vbmc_conf)
 
 def prepare_libraries():
     run_command("cp /usr/local/etc/infrasim/lib/* /usr/local/lib/", True, None, None)
@@ -94,6 +88,7 @@ def prepare_libraries():
     run_command("cd /usr/local/lib && ln -sf libOpenIPMIutils.so.0.0.1 libOpenIPMIutils.so.0")
     run_command("cd /usr/local/lib && ln -sf libOpenIPMIutils.so.0.0.1 libOpenIPMIutils.so")
     run_command("ldconfig")
+
 
 def prepare_seabios():
     if os.path.exists('/usr/local/share/qemu') is False:

--- a/bin/infrasim-main
+++ b/bin/infrasim-main
@@ -16,10 +16,10 @@ if __name__ == '__main__':
     node = ""
     eth = ""
 
-    if has_option(conf, "compute", "name"):
-        node = conf["compute"]["name"]
+    if has_option(conf, "type"):
+        node = conf["type"]
     else:
-        print "Can't get infrasim node name.\n" \
+        print "Can't get infrasim type.\n" \
               "Please check infrasim configure file: {}".format(INFRASIM_CONF)
         sys.exit(-1)
 
@@ -41,7 +41,7 @@ if __name__ == '__main__':
 
         if sys.argv[1] == "start":
             socat.start_socat()
-            ipmi.start_ipmi(node)
+            ipmi.start_ipmi()
             print "Infrasim service started.\n" \
               "You can access virtual {} via vnc:{}:5901".format(node, netifaces.ifaddresses(eth)[netifaces.AF_INET][0]['addr'])
         elif sys.argv[1] == "stop":
@@ -59,7 +59,7 @@ if __name__ == '__main__':
             socat.stop_socat()
             print "Restart InfraSIM service..."
             socat.start_socat()
-            ipmi.start_ipmi(node)
+            ipmi.start_ipmi()
         else:
             print "{} start|stop|status|restart".format(sys.argv[0])
     except CommandRunFailed as e:

--- a/data/conf/infrasim.yml
+++ b/data/conf/infrasim.yml
@@ -1,18 +1,19 @@
 ---
 #This file is used as InfraSIM configuration file
 
+#Node type of your infrasim compute, this will determine the
+#bmc emulation data and bios binary to use.
+#Supported compute node names:
+#	quanta_d51
+#	quanta_t41
+#	dell_c6320
+#	dell_r630
+#	s2600kp
+#	s2600tp
+#	s2600wtt
+type: quanta_d51
+
 compute:
-    #Node type of your infrasim compute, this will determine the
-    #bmc emulation data and bios binary to use.
-    #Supported compute node names:
-    #	quanta_d51
-    #	quanta_t41
-    #	dell_c6320
-    #	dell_r630
-    #	s2600kp
-    #	s2600tp
-    #	s2600wtt
-    name: quanta_d51
 
     cpu:
         #Set node cpu num, the default value is 2

--- a/infrasim/__init__.py
+++ b/infrasim/__init__.py
@@ -3,12 +3,15 @@
 import logging
 import subprocess
 
+VM_DEFAULT_CONFIG = "/etc/infrasim/infrasim.yml"
+
 logger = logging.getLogger()
 hdlr = logging.FileHandler('/var/log/inframsim.log')
 formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
 hdlr.setFormatter(formatter)
 logger.addHandler(hdlr)
 logger.setLevel(logging.NOTSET)
+
 
 def run_command(cmd="", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE):
     """

--- a/infrasim/ipmi.py
+++ b/infrasim/ipmi.py
@@ -2,7 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import os
-from . import run_command, logger, CommandNotFound, CommandRunFailed
+import yaml
+from . import run_command, logger, ArgsNotCorrect, CommandNotFound, CommandRunFailed, VM_DEFAULT_CONFIG
+from model import CBMC
+
 
 def get_ipmi():
     try:
@@ -11,22 +14,38 @@ def get_ipmi():
     except CommandRunFailed as e:
         raise CommandNotFound("/usr/local/bin/ipmi_sim")
 
+
 def status_ipmi():
     try:
         run_command("pidof ipmi_sim")
         print "InfraSim IPMI service is running"
     except CommandRunFailed as e:
         print "Infrasim IPMI service is stopped"
- 
-def start_ipmi(node):
-    ipmi_cmd = get_ipmi()
-    ipmi_start_cmd = "{0} -c /etc/infrasim/vbmc.conf" \
-                    " -f /usr/local/etc/infrasim/{1}/{1}.emu -n -s /var/tmp > /var/log/openipmi.log &".format(ipmi_cmd, node)
+
+
+def start_ipmi(conf=VM_DEFAULT_CONFIG):
     try:
-        run_command(ipmi_start_cmd, True, None, None)
-        logger.info("ipmi start")
+        with open(conf, 'r') as f_yml:
+            conf = yaml.load(f_yml)
+        if "bmc" in conf:
+            bmc = CBMC(conf["bmc"])
+        else:
+            bmc = CBMC()
+        bmc.set_type(conf["type"])
+        bmc.init()
+        bmc.precheck()
+        cmd = "{} > /var/log/openipmi.log &".format(bmc.get_commandline())
+        logger.debug(cmd)
+        run_command(cmd, True, None, None)
+
+        logger.info("bmc start")
     except CommandRunFailed as e:
+        logger.error(e.value)
         raise e
+    except ArgsNotCorrect as e:
+        logger.error(e.value)
+        raise e
+
 
 def stop_ipmi():
     ipmi_stop_cmd = "pkill ipmi_sim"

--- a/infrasim/qemu.py
+++ b/infrasim/qemu.py
@@ -5,11 +5,8 @@ import os
 import yaml
 import socket
 import time
-import netifaces
-from . import run_command, logger, CommandNotFound, CommandRunFailed, ArgsNotCorrect, has_option
+from . import run_command, logger, CommandNotFound, CommandRunFailed, ArgsNotCorrect, has_option, VM_DEFAULT_CONFIG
 from model import CCompute
-
-VM_DEFAULT_CONFIG = "/etc/infrasim/infrasim.yml"
 
 
 def get_qemu():
@@ -51,6 +48,7 @@ def start_qemu(conf=VM_DEFAULT_CONFIG):
         with open(conf, 'r') as f_yml:
             conf = yaml.load(f_yml)
         compute = CCompute(conf["compute"])
+        compute.set_type(conf["type"])
         compute.init()
         compute.precheck()
         cmd = "{} 2>/var/log/qemu.log &".format(compute.get_commandline())

--- a/test/functional/test_ipmi_chassis.py
+++ b/test/functional/test_ipmi_chassis.py
@@ -38,7 +38,7 @@ power_reset_cmd = cmd_prefix + 'power reset'
 class test_ipmi_command_chassis_control(unittest.TestCase):
     def setUp(self):
         socat.start_socat()
-        ipmi.start_ipmi("quanta_d51")
+        ipmi.start_ipmi()
         time.sleep(3)
 
     def tearDown(self):

--- a/test/functional/test_ipmi_command_response.py
+++ b/test/functional/test_ipmi_command_response.py
@@ -51,7 +51,7 @@ class test_ipmicommand_response(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         socat.start_socat()
-        ipmi.start_ipmi("quanta_d51")
+        ipmi.start_ipmi()
         time.sleep(3)
 
     @classmethod

--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -69,7 +69,7 @@ class test_ipmi_console(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         socat.start_socat()
-        ipmi.start_ipmi('quanta_d51')
+        ipmi.start_ipmi()
         run_command('ipmi-console start &', True, None, None)
         time.sleep(5)
         cls.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/test/unit/test_core_process.py
+++ b/test/unit/test_core_process.py
@@ -10,11 +10,10 @@ Check:
     - corresponding process can be started by start service
     - corresponding process can be ended by stop service
 """
-import time
+
 from infrasim import qemu
 from infrasim import ipmi
 from infrasim import socat
-from infrasim import run_command
 import time
 from nose.tools import assert_raises
 
@@ -26,12 +25,14 @@ def test_qemu_exist():
     except:
         assert False
 
+
 def test_ipmi_exist():
     try:
         ipmi.get_ipmi()
         assert True
     except:
         assert False
+
 
 def test_socat_exist():
     try:
@@ -42,14 +43,15 @@ def test_socat_exist():
 
 
 def test_socat_process_start():
-     try:
-         socat.start_socat()
-         ipmi.start_ipmi("quanta_d51")
-         time.sleep(3)
-         socat.status_socat()
-         assert True
-     except:
-         assert False
+    try:
+        socat.start_socat()
+        ipmi.start_ipmi()
+        time.sleep(3)
+        socat.status_socat()
+        assert True
+    except:
+        assert False
+
 
 def test_ipmi_process_start():
     try:
@@ -58,12 +60,14 @@ def test_ipmi_process_start():
     except:
         assert False
 
+
 def test_qemu_process_start():
     try:
         qemu.status_qemu()
         assert True
     except:
         assert False
+
 
 def test_qemu_process_status_running():
     try:
@@ -72,6 +76,7 @@ def test_qemu_process_status_running():
     except:
         assert False
 
+
 def test_ipmi_process_status_running():
     try:
         ipmi.status_ipmi()
@@ -79,12 +84,14 @@ def test_ipmi_process_status_running():
     except:
         assert False
 
+
 def test_socat_process_status_running():
     try:
         socat.status_socat()
         assert True
     except:
         assert False
+
 
 def test_qemu_prcess_stop():
     try:
@@ -94,6 +101,7 @@ def test_qemu_prcess_stop():
     except:
         assert True
 
+
 def test_ipmi_process_stop():
     try:
         ipmi.stop_ipmi()
@@ -101,6 +109,7 @@ def test_ipmi_process_stop():
         assert False
     except:
         assert True
+
 
 def test_socat_process_stop():
      try:


### PR DESCRIPTION
[->] Enable CBMC
[  ] Update jinja template of vbmc.conf with more customization
[  ] Enable socat
[  ] Enable task schedule to start/stop socat, bmc, qemu
[  ] Scrub infrasim.yml to avoid duplicated definition

**vbmc.conf generate time**
Previously, vbmc.conf is rendered in infrasim-init.
But now, it is rendered in infrasim-main start, with necessary
information defined in infrasim.yml.

**Incorporate CBMC() implementation**
ipmi.start_ipmi() now take configuration file instead of node
name and the file is by default set to infrasim.yml
All test are updated accordinly.

**Be ready for node**
Define node type outside qemu and bmc.
So will be shared port

   9000: ipmi_sim <> ipmi-console
   9002: ipmi_sim <> qemu
   9003: socat <> qemu
   pty0: ipmi_sim <> socat

Because similar settings are a concept in node wise instead of
qemu/socat/openipmi wise.