### PR TITLE
feature/vbmc_conf_template

### DIFF
--- a/data/conf/vbmc.conf
+++ b/data/conf/vbmc.conf
@@ -16,7 +16,7 @@ set_working_mc 0x20
     # Define an IP address and port to listen on.  You can define more
     # than one address/port to listen on multiple addresses.  The ::
     # listens on all addresses.
-    addr :: 623
+    addr :: {{port_iol}}
 
     # Maximum privilege limit on the channel.
     priv_limit admin
@@ -36,26 +36,26 @@ set_working_mc 0x20
     #bmc_key "abcdefghijklmnopqrst"
 
     # A program to get and set the LAN configuration of the interface.
-    lan_config_program "/usr/local/etc/infrasim/script/lancontrol {{nic}}"
+    lan_config_program "{{lan_control_script}} {{lan_interface}}"
   endlan
 
-  chassis_control "/usr/local/etc/infrasim/script/chassiscontrol 0x20"
+  chassis_control "{{chassis_control_script}} 0x20"
 
   # Define a serial VM inteface for channel 15 (the system interface) on
-  # port 9002, just available to the local system (localhost).
-  serial 15 0.0.0.0 9002 codec VM ipmb 0x20
+  # port {{port_qemu_ipmi}}, just available to the local system (localhost).
+  serial 15 0.0.0.0 {{port_qemu_ipmi}} codec VM ipmb 0x20
 
   # startcmd is what to execute to start a VM associated with the
-  # codec above (localhost 9002).  It also starts a console serial port
-  # on port 9003 that is also used as the monitor interface.
+  # codec above (localhost {{port_qemu_ipmi}}).  It also starts a console serial port
+  # as the monitor interface.
 
-  startcmd "/usr/local/etc/infrasim/script/startcmd"
+  startcmd "{{startcmd_script}}"
 
-  # Set up telnet session for ipmi simulator on port 9000
-  console 0.0.0.0 9000
+  # Set up telnet session for ipmi simulator on port {{port_ipmi_console}}
+  console 0.0.0.0 {{port_ipmi_console}}
 
   # Start startcmd at startup?  Default is false.
-  startnow true
+  startnow {{startnow}}
 
   # The amount of time to wait for the startcmd to do a graceful shutdown
   # on a powerdown request.  The simulator will send a request to the
@@ -64,18 +64,18 @@ set_working_mc 0x20
   # Note that if the simulator does not have a connection to the VM, the
   # graceful shutdown is skipped and a SIGTERM is done immediately.
   # Default time is 60 seconds.
-  poweroff_wait 5
+  poweroff_wait {{poweroff_wait}}
 
   # The amount of time to wait for SIGTERM to kill the process.  If the process
   # does not terminate in this period of time, send a SIGKILL kill.  If this
   # is zero, don't send the SIGKILL.  Default time is 20 seconds.
-  kill_wait 1
+  kill_wait {{kill_wait}}
 
   # Now add some users.  User 0 is invalid, user 1 is the special "anonymous"
   # user and cannot take a username.  Note that the users here are only
   # used if the persistent user config doesn't exist.
   #    # valid name    passw      priv-lim max-sess allowed-auths
   user 1 true  ""      "test"     user     10       none md2 md5 straight
-  user 2 true  "admin" "admin" admin    10       none md2 md5 straight
+  user 2 true  "{{username}}" "{{password}}" admin    10       none md2 md5 straight
 
-  sol "/etc/infrasim/pty0" 115200 history=4000 historyfru=10
+  sol "{{sol_device}}" 115200 history=4000 historyfru={{historyfru}}

--- a/etc/vbmc.conf.example
+++ b/etc/vbmc.conf.example
@@ -36,10 +36,10 @@ set_working_mc 0x20
     #bmc_key "abcdefghijklmnopqrst"
 
     # A program to get and set the LAN configuration of the interface.
-    lan_config_program "/usr/local/etc/infrasim/lancontrol eth0"
+    lan_config_program "/usr/local/etc/infrasim/script/lancontrol eth0"
   endlan
 
-  chassis_control "/usr/local/etc/infrasim/chassiscontrol 0x20"
+  chassis_control "/usr/local/etc/infrasim/script/chassiscontrol 0x20"
 
   # Define a serial VM inteface for channel 15 (the system interface) on
   # port 9002, just available to the local system (localhost).
@@ -47,9 +47,9 @@ set_working_mc 0x20
 
   # startcmd is what to execute to start a VM associated with the
   # codec above (localhost 9002).  It also starts a console serial port
-  # on port 9003 that is also used as the monitor interface.
+  # as the monitor interface.
 
-  startcmd "/usr/local/etc/infrasim/startcmd"
+  startcmd "/usr/local/etc/infrasim/script/startcmd"
 
   # Set up telnet session for ipmi simulator on port 9000
   console 0.0.0.0 9000


### PR DESCRIPTION
[  ] Enable CBMC
[->] Update jinja template of vbmc.conf with more customization
[  ] Enable socat
[  ] Enable task schedule to start/stop socat, bmc, qemu
[  ] Scrub infrasim.yml to avoid duplicated definition

**Enable more customization for bmc feature**

    bmc:
	    interface
		lancontrol
		chassiscontrol
		startcmd
		startnow
		poweroff_wait
		kill_wait
		emu_file
		config_file
		ipmi_over_lan_port
		historyfru

		username
		password

Please check etc/vbmc.conf.example for detail explaination.

**Added test**
1. Unit test for serveral BMC attributes
2. Functional test for IOL port customization