### PR TITLE
feature/enable_socat

### DIFF
--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1024,7 +1024,39 @@ class CBMC(Task):
 
 class CSocat(Task):
     def __init__(self):
+        super(CSocat, self).__init__()
+
+        self.__bin = None
+
+        # Node wise attributes
+        self.__port_serial = 9003
+        self.__sol_device = "/etc/infrasim/pty0"
+
+    def set_port_serial(self, port):
+        self.__port_serial = port
+
+    def set_sol_device(self, device):
+        self.__sol_device = device
+
+    def precheck(self):
+
+        # check if socat exists
+        try:
+            code, socat_cmd = run_command("which /usr/bin/socat")
+            self.__bin = socat_cmd.strip(os.linesep)
+        except CommandRunFailed:
+            raise CommandNotFound("/usr/bin/socat")
+
+        # check ports are in use
+
+    def init(self):
         pass
+
+    def get_commandline(self):
+        socat_str = "{0} pty,link={1},waitslave " \
+                    "udp-listen:{2},reuseaddr,fork".\
+            format(self.__bin, self.__sol_device, self.__port_serial)
+        return socat_str
 
 
 class CNode(object):

--- a/infrasim/socat.py
+++ b/infrasim/socat.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os, time
-from . import run_command, logger, CommandNotFound, CommandRunFailed
+import os
+import time
+import yaml
+from infrasim.model import CSocat
+from . import run_command, logger, CommandNotFound, CommandRunFailed, VM_DEFAULT_CONFIG
+
 
 def get_socat():
     try:
@@ -11,6 +15,7 @@ def get_socat():
     except CommandRunFailed as e:
         raise CommandNotFound("/usr/bin/socat")
 
+
 def status_socat():
     try:
         run_command("pidof socat")
@@ -18,16 +23,30 @@ def status_socat():
     except CommandRunFailed as e:
         print "Inrasim Socat service is stopped"
 
-def start_socat():
-    socat_cmd = get_socat()
-    socat_start_cmd = "{} pty,link=/etc/infrasim/pty0,waitslave udp-listen:9003," \
-                      "reuseaddr,fork &".format(socat_cmd)
+
+def start_socat(conf=VM_DEFAULT_CONFIG):
     try:
-        run_command(socat_start_cmd, True, None, None)
+        with open(conf, 'r') as f_yml:
+            conf = yaml.load(f_yml)
+
+        socat = CSocat()
+        # Read SOL device, serial port from conf
+        # and set to socat
+        if "sol_device" in conf:
+            socat.set_sol_device(conf["sol_device"])
+        if "serial_port" in conf:
+            socat.set_port_serial(conf["serial_port"])
+
+        socat.init()
+        socat.precheck()
+        cmd = "{} &".format(socat.get_commandline())
+
+        run_command(cmd, True, None, None)
         time.sleep(3)
         logger.info("socat start")
     except CommandRunFailed as e:
         raise e
+
 
 def stop_socat():
     socat_stop_cmd = "pkill socat"

--- a/test/functional/test_serial.py
+++ b/test/functional/test_serial.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Test serial functions:
+    - socat can create serial device
+    - qemu connect to it
+    - SOL (serial over lan) work as expected
+"""
+import unittest
+import os
+import yaml
+from infrasim import socat, VM_DEFAULT_CONFIG
+
+
+class test_serial(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        socat.stop_socat()
+
+    def setUp(self):
+        os.system("touch test.yml")
+        with open(VM_DEFAULT_CONFIG, 'r') as f_yml:
+            self.conf = yaml.load(f_yml)
+
+    def tearDown(self):
+        self.conf = None
+        socat.stop_socat()
+        os.system("rm -rf test.yml")
+
+    def test_socat_create_serial_device_file(self):
+        target_device = "./pty_serial"
+        if os.path.isfile(target_device) or os.path.islink(target_device):
+            os.system("rm {}".format(target_device))
+
+        # Start socat and device shall be created
+        self.conf["sol_device"] = target_device
+        with open("test.yml", "w") as yaml_file:
+            yaml.dump(self.conf, yaml_file, default_flow_style=False)
+        socat.start_socat("test.yml")
+
+        if os.path.islink(target_device):
+            assert True
+        else:
+            assert False
+
+        # Remove socat and device shall be collected
+        socat.stop_socat()
+        if os.path.isfile(target_device) or os.path.islink(target_device):
+            assert False
+        else:
+            assert True

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -490,3 +490,20 @@ class bmc_configuration(unittest.TestCase):
                    in str(e)
         else:
             assert False
+
+
+class socat_configuration(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        socat.stop_socat()
+
+    def test_default_socat(self):
+        socat_obj = model.CSocat()
+
+        socat_obj.init()
+        socat_obj.precheck()
+        cmd = socat_obj.get_commandline()
+
+        assert "pty,link=/etc/infrasim/pty0,waitslave" in cmd
+        assert "udp-listen:9003,reuseaddr,fork" in cmd


### PR DESCRIPTION
[  ] Enable CBMC
[  ] Update jinja template of vbmc.conf with more customization
[->] Enable socat
[  ] Enable task schedule to start/stop socat, bmc, qemu
[  ] Scrub infrasim.yml to avoid duplicated definition

**Added socat definition in model**
Two attributes are expected in yaml file:

    sol_device  # default is /etc/infrasim/pty0
	serial_port  # default is 9003

The command to start socat is changed to CSocat's method

**Added test**
Unit test to test default socat command line
Functional test to test socat shall prepare SOL device file and
collect it if stops