### PR TITLE
Feature/integrate qemu ipmi socat

### DIFF
--- a/bin/infrasim-init
+++ b/bin/infrasim-init
@@ -55,6 +55,12 @@ def create_infrasim_directories():
         os.system("rm -rf /usr/local/libexec")
         os.mkdir("/usr/local/libexec")
 
+    if os.path.exists("/var/log/infrasim") is False:
+        os.mkdir("/var/log/infrasim")
+    else:
+        os.system("rm -rf /var/log/infrasim")
+        os.mkdir("/var/log/infrasim")
+
 
 def create_infrasim_conf():
 

--- a/bin/infrasim-main
+++ b/bin/infrasim-main
@@ -46,7 +46,9 @@ if __name__ == '__main__':
             node.precheck()
             node.start()
             print "Infrasim service started.\n" \
-              "You can access virtual {} via vnc:{}:5901".format(node, netifaces.ifaddresses(eth)[netifaces.AF_INET][0]['addr'])
+              "You can access node {} via vnc:{}:5901".\
+                format(node.get_node_name(),
+                       netifaces.ifaddresses(eth)[netifaces.AF_INET][0]['addr'])
         elif sys.argv[1] == "stop":
             node.init()
             node.stop()

--- a/bin/infrasim-main
+++ b/bin/infrasim-main
@@ -4,7 +4,7 @@
 import sys
 import yaml
 import netifaces
-from infrasim import ipmi, socat, run_command, qemu, CommandRunFailed, ArgsNotCorrect, has_option
+from infrasim import ipmi, socat, run_command, qemu, CommandRunFailed, ArgsNotCorrect, has_option, model
 
 INFRASIM_CONF = "/etc/infrasim/infrasim.yml"
 VERSION_CONF = "/usr/local/etc/infrasim/conf/version.yml"
@@ -14,7 +14,6 @@ if __name__ == '__main__':
     with open(INFRASIM_CONF, 'r') as f_yml:
         conf = yaml.load(f_yml)
 
-    node = ""
     eth = ""
 
     if has_option(conf, "type"):
@@ -35,32 +34,32 @@ if __name__ == '__main__':
               "Please check infrasim configure file: {}".format(INFRASIM_CONF)
         sys.exit(-1)
 
+    node = model.CNode(conf)
+
     try:
         if len(sys.argv) < 2:
             print "{} start|stop|status|restart|version".format(sys.argv[0])
             sys.exit(0)
 
         if sys.argv[1] == "start":
-            socat.start_socat()
-            ipmi.start_ipmi()
+            node.init()
+            node.precheck()
+            node.start()
             print "Infrasim service started.\n" \
               "You can access virtual {} via vnc:{}:5901".format(node, netifaces.ifaddresses(eth)[netifaces.AF_INET][0]['addr'])
         elif sys.argv[1] == "stop":
-            qemu.stop_qemu()
-            ipmi.stop_ipmi()
-            socat.stop_socat()
+            node.init()
+            node.stop()
             print "Infrasim Service stopped"
         elif sys.argv[1] == "status":
-            qemu.status_qemu()
-            ipmi.status_ipmi()
-            socat.status_socat()
+            node.init()
+            node.status()
         elif sys.argv[1] == "restart":
-            qemu.stop_qemu()
-            ipmi.stop_ipmi()
-            socat.stop_socat()
+            node.init()
+            node.stop()
             print "Restart InfraSIM service..."
-            socat.start_socat()
-            ipmi.start_ipmi()
+            node.precheck()
+            node.start()
         elif sys.argv[1] == "version":
             qemu_ver_cmd = qemu.get_qemu() + " --version"
             ipmi_ver_cmd = ipmi.get_ipmi() + " -v"
@@ -78,6 +77,8 @@ if __name__ == '__main__':
         else:
             print "{} start|stop|status|restart|version".format(sys.argv[0])
     except CommandRunFailed as e:
+        import traceback
+        print traceback.format_exc()
         print "{} run failed\n".format(e.value)
         print "Infrasim-main starts failed"
     except ArgsNotCorrect as e:

--- a/bin/infrasim-main
+++ b/bin/infrasim-main
@@ -50,6 +50,7 @@ if __name__ == '__main__':
         elif sys.argv[1] == "stop":
             node.init()
             node.stop()
+            node.terminate_workspace()
             print "Infrasim Service stopped"
         elif sys.argv[1] == "status":
             node.init()
@@ -77,8 +78,6 @@ if __name__ == '__main__':
         else:
             print "{} start|stop|status|restart|version".format(sys.argv[0])
     except CommandRunFailed as e:
-        import traceback
-        print traceback.format_exc()
         print "{} run failed\n".format(e.value)
         print "Infrasim-main starts failed"
     except ArgsNotCorrect as e:

--- a/data/script/chassiscontrol
+++ b/data/script/chassiscontrol
@@ -47,7 +47,11 @@ do_get() {
 	case $1 in
 	    power)
 		val=1
-		pid=`pidof qemu-system-x86_64`
+		if [ ! -f "{{qemu_pid_file}}" ]; then
+		    pid=""
+		else
+		    pid=`cat {{qemu_pid_file}}`
+		fi
 		if [ "x$pid" = "x" ]; then
 			val=0
 		fi
@@ -89,7 +93,11 @@ do_set() {
 	case $parm in
 	    power)
             do_log "receive power signal parm=$parm val=$val"
-            pid=`pidof qemu-system-x86_64`
+            if [ ! -f "{{qemu_pid_file}}" ]; then
+                pid=""
+            else
+                pid=`cat {{qemu_pid_file}}`
+            fi
             if [ "x$val" = "x1" ]; then
                 if [ "x$pid" = "x" ]; then
                     {{startcmd}}

--- a/data/script/chassiscontrol
+++ b/data/script/chassiscontrol
@@ -92,19 +92,19 @@ do_set() {
             pid=`pidof qemu-system-x86_64`
             if [ "x$val" = "x1" ]; then
                 if [ "x$pid" = "x" ]; then
-                    /usr/local/etc/infrasim/script/startcmd
+                    {{startcmd}}
                 else
                     do_log "host already powered on pid=$pid"
                 fi
             fi
             if [ "x$val" = "x0" ]; then
-                    /usr/local/etc/infrasim/script/stopcmd
+                    {{stopcmd}}
                     do_log "host stopped"
             fi
             ;;
 	    reset)
             do_log "receive reset signal parm=$parm val=$val"
-            /usr/local/etc/infrasim/script/resetcmd
+            {{resetcmd}}
             ;;
 	    boot)
             do_log "receive boot signal parm=$parm val=$val"

--- a/data/script/resetcmd
+++ b/data/script/resetcmd
@@ -1,2 +1,2 @@
 #!/bin/bash
-python -c 'from infrasim import qemu; qemu.stop_qemu();  qemu.start_qemu();'
+python -c 'from infrasim import qemu; qemu.stop_qemu("{{yml_file}}");  qemu.start_qemu("{{yml_file}}");'

--- a/data/script/startcmd
+++ b/data/script/startcmd
@@ -1,2 +1,2 @@
 #!/bin/bash
-python -c 'from infrasim import qemu; qemu.start_qemu()'
+python -c 'from infrasim import qemu; qemu.start_qemu("{{yml_file}}")'

--- a/data/script/stopcmd
+++ b/data/script/stopcmd
@@ -1,2 +1,2 @@
 #!/bin/bash
-python -c 'from infrasim import qemu; qemu.stop_qemu()'
+python -c 'from infrasim import qemu; qemu.stop_qemu("{{yml_file}}")'

--- a/etc/infrasim.full.yml.example
+++ b/etc/infrasim.full.yml.example
@@ -1,0 +1,79 @@
+# Unique identifier
+name: node-1
+
+# Node type is mandatory
+type: quanta_d51
+
+compute:
+    kvm_enabled: true
+    cpu:
+        model: host
+        features: +vmx
+        quantities: 8
+    memory:
+        size: 4096
+    storage_backend:
+        -
+            controller:
+                type: ahci
+                max_drive_per_controller: 6
+                drives:
+                -
+                    model: SATADOM
+                    serial: HUSMM142
+                    bootindex: 1
+                    # To boot esxi, please set ignore_msrs to Y
+                    # sudo -i
+                    # echo 1 > /sys/module/kvm/parameters/ignore_msrs
+                    # cat /sys/module/kvm/parameters/ignore_msrs
+                    file: chassis/node1/esxi6u2-1.qcow2
+                -
+                    vendor: Hitachi
+                    model: HUSMM0SSD
+                    serial: 0SV3XMUA
+                    # To set rotation to 1 (SSD), need some customization
+                    # on qemu
+                    # rotation: 1
+                    # Use RAM-disk to accelerate IO
+                    file: /dev/ram0
+                -
+                    vendor: Samsung
+                    model: SM162521
+                    serial: S0351X2B
+                    # Create your disk image first
+                    # e.g. qemu-img create -f qcow2 sda.img 2G
+                    file: chassis/node1/sda.img
+                -
+                    vendor: Samsung
+                    model: SM162521
+                    serial: S0351X3B
+                    file: chassis/node1/sdb.img
+                -
+                    vendor: Samsung
+                    model: SM162521
+                    serial: S0451X2B
+                    file: chassis/node1/sdc.img
+    networks:
+        -
+            type: bridge
+            bridge: br0
+            device: vmxnet3
+        -
+            type: bridge
+            bridge: br0
+            device: vmxnet3
+    ipmi:
+        interface: bt
+        host: 127.0.0.1
+    smbios: chassis/node1/quanta_d51_smbios.bin
+bmc:
+    interface: br0
+    username: admin
+    password: admin
+    emu_file: chassis/node1/quanta_d51.emu
+
+# Used by ipmi_sim and
+bmc_connection_port: 9100
+
+# Renamed from telnet_listen_port to ipmi_console_port, extracted from bmc
+ipmi_console_port: 9000

--- a/etc/infrasim.yml.example
+++ b/etc/infrasim.yml.example
@@ -1,16 +1,17 @@
 ---
 #This file is used as InfraSIM configuration file
 
-main:
-    #Supported vnode names:
-    #	quanta_d51
-    #	quanta_t41
-    #	dell_c6320
-    #	dell_r630
-    #	s2600kp
-    #	s2600tp
-    #	s2600wtt
-    node: quanta_d51
+#Node type of your infrasim compute, this will determine the
+#bmc emulation data and bios binary to use.
+#Supported compute node names:
+#	quanta_d51
+#	quanta_t41
+#	dell_c6320
+#	dell_r630
+#	s2600kp
+#	s2600tp
+#	s2600wtt
+type: quanta_d51
 
 node:
     #Set node cpu num, the default value is 2

--- a/etc/infrasim.yml.example
+++ b/etc/infrasim.yml.example
@@ -35,27 +35,47 @@ node:
     #
     memory: 1024
 
-    #Set node disks num, the default is 1
-    #
-    disk_num: 1
+    storage_backend:
+        #Set drive list and define drive attributes
+        -
+            controller:
+                type: ahci
+                max_drive_per_controller: 8
+                drives:
 
-    #Set node disk size, the unit is GB.
-    #The default value is 8GB
-    #
-    disk_size: 8
+                -
+                    #Set node disk size, the unit is GB.
+                    #The default value is 8GB
+                    #
+                    size: 8
 
-    #Set node network mode for qemu. The options shuld be:
-    #	nat		--default
-    #	macvtap
-    #	bridge
-    network_mode: nat
 
-    #If you use bridge mode, please specify the network_name
-    network_name: ens33
+    networks:
+        #Set network list and define drive attributes
+        #
 
-    network_mac1: 52:54:00:ad:66:b5
-    #network_mac2: 52:54:00:ac:45:56
-    #network_mac3: 52:54:00:23:6f:13
+        -
+            #Set node network mode for qemu. The options should be:
+            #   nat             --default
+            #   macvtap
+            #   bridge
+            #
+            network_mode: nat
+
+            #If you use bridge mode, please specify this with bridge name
+            #
+            network_name: ens160
+
+            #Set network device for qemu. The options should be:
+            #   vmxnet3 --default
+            #   e1000
+            device: vmxnet3
+
+            #Set MAC for this network, this MAC is generated with
+            #datetime as random seed, but you can specify yours
+            #
+            mac: 00:60:16:9e:a8:e9
+
 
     #Set cdrom ISO file for OS Installation
     #cdrom=

--- a/infrasim/ipmi.py
+++ b/infrasim/ipmi.py
@@ -27,12 +27,15 @@ def start_ipmi(conf_file=VM_DEFAULT_CONFIG):
     try:
         with open(conf_file, 'r') as f_yml:
             conf = yaml.load(f_yml)
-        if "bmc" in conf:
-            bmc = CBMC(conf["bmc"])
-        else:
-            bmc = CBMC()
+
+        bmc = CBMC(conf.get('bmc', {}))
+        node_name = conf["name"] if "name" in conf else "node-0"
+        bmc.set_task_name("{}-bmc".format(node_name))
+        bmc.set_log_path("/var/log/infrasim/{}/openipmi.log".
+                         format(node_name))
         bmc.set_type(conf["type"])
         bmc.init()
+        bmc.write_bmc_config()
         bmc.precheck()
         cmd = bmc.get_commandline()
         logger.debug(cmd)

--- a/infrasim/ipmi.py
+++ b/infrasim/ipmi.py
@@ -23,9 +23,9 @@ def status_ipmi():
         print "Infrasim IPMI service is stopped"
 
 
-def start_ipmi(conf=VM_DEFAULT_CONFIG):
+def start_ipmi(conf_file=VM_DEFAULT_CONFIG):
     try:
-        with open(conf, 'r') as f_yml:
+        with open(conf_file, 'r') as f_yml:
             conf = yaml.load(f_yml)
         if "bmc" in conf:
             bmc = CBMC(conf["bmc"])
@@ -34,9 +34,9 @@ def start_ipmi(conf=VM_DEFAULT_CONFIG):
         bmc.set_type(conf["type"])
         bmc.init()
         bmc.precheck()
-        cmd = "{} > /var/log/openipmi.log &".format(bmc.get_commandline())
+        cmd = bmc.get_commandline()
         logger.debug(cmd)
-        run_command(cmd, True, None, None)
+        run_command(cmd+" &", True, None, None)
 
         logger.info("bmc start")
     except CommandRunFailed as e:

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -789,14 +789,14 @@ class CCompute(Task, CElement):
             if self.__compute['kvm_enabled']:
                 if os.path.exists("/dev/kvm"):
                     self.__enable_kvm = True
-                    logger.log('[model:compute] infrasim has enabled kvm')
+                    logger.info('[model:compute] infrasim has enabled kvm')
                 else:
                     self.__enable_kvm = False
                     logger.warning('[model:compute] infrasim can\'t '
                                    'enable kvm on this environment')
             else:
                 self.__enable_kvm = False
-                logger.log('[model:compute] infrasim doesn\'t enable kvm')
+                logger.info('[model:compute] infrasim doesn\'t enable kvm')
 
         if 'smbios' in self.__compute:
             self.__smbios = self.__compute['smbios']
@@ -822,10 +822,10 @@ class CCompute(Task, CElement):
                 and self.__compute['numa_control']:
             if os.path.exists("/usr/bin/numactl"):
                 self.set_numactl(NumaCtl())
-                logger.log('[model:compute] infrasim has '
+                logger.info('[model:compute] infrasim has '
                            'enabled numa control')
             else:
-                logger.log('[model:compute] infrasim can\'t '
+                logger.info('[model:compute] infrasim can\'t '
                            'find numactl in this environment')
 
         cpu_obj = CCPU(self.__compute['cpu'])
@@ -842,11 +842,19 @@ class CCompute(Task, CElement):
         backend_network_obj = CBackendNetwork(self.__compute['networks'])
         self.__element_list.append(backend_network_obj)
 
-        ipmi_obj = CIPMI({
-            "interface": "kcs",
-            "host": "127.0.0.1",
-            "bmc_connection_port": self.__port_qemu_ipmi
-        })
+        if has_option(self.__compute, "ipmi"):
+            ipmi_obj = CIPMI({
+                "interface": self.__compute["ipmi"].get("interface", "kcs"),
+                "host": self.__compute["ipmi"].get("host", "127.0.0.1"),
+                "bmc_connection_port": self.__port_qemu_ipmi
+            })
+        else:
+            ipmi_obj = CIPMI({
+                "interface": "kcs",
+                "host": "127.0.0.1",
+                "bmc_connection_port": self.__port_qemu_ipmi
+            })
+
         self.__element_list.append(ipmi_obj)
 
         for element in self.__element_list:

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -528,7 +528,8 @@ class CNetwork(CElement):
         elif self.__network_mode == "nat":
             network_option = "-net user -net nic"
         else:
-            raise Exception("ERROR: {} is not supported now.".format(self.__network_mode))
+            raise Exception("ERROR: {} is not supported now.".
+                            format(self.__network_mode))
 
         self.add_option(network_option)
 
@@ -590,7 +591,8 @@ class CIPMI(CElement):
     def handle_parms(self):
         chardev_option = ','.join(["socket", 'id=ipmi0',
                                    'host={}'.format(self.__host),
-                                   'port={}'.format(self.__bmc_connection_port),
+                                   'port={}'.
+                                  format(self.__bmc_connection_port),
                                    'reconnect=10'])
         bmc_option = ','.join(['ipmi-bmc-extern', 'chardev=ipmi0', 'id=bmc0'])
         interface_option = ','.join(['isa-ipmi-kcs', 'bmc=bmc0'])
@@ -666,7 +668,8 @@ class Task(object):
                 if time.time()-start > 5:
                     break
             if pid is None:
-                print "[ {:<6} ] {} fail to start".format(pid, self.__task_name)
+                print "[ {:<6} ] {} fail to start".\
+                    format(pid, self.__task_name)
             else:
                 print "[ {:<6} ] {} run".format(pid, self.__task_name)
             return
@@ -678,7 +681,8 @@ class Task(object):
         pid = self.get_task_pid()
         if pid > 0:
             if os.path.exists("/proc/{}".format(pid)):
-                print "[ {:<6} ] {} is already running".format(pid, self.__task_name)
+                print "[ {:<6} ] {} is already running".\
+                    format(pid, self.__task_name)
                 return
             else:
                 os.remove("{}/.{}".format(self.__workspace, self.__task_name))
@@ -706,7 +710,8 @@ class Task(object):
             if not os.path.exists("/proc/{}".format(task_pid)):
                 pass
             else:
-                print("[ {:<6} ] {} stop failed.".format(task_pid, self.__task_name))
+                print("[ {:<6} ] {} stop failed.".
+                      format(task_pid, self.__task_name))
 
     def status(self):
         task_pid = self.get_task_pid()
@@ -719,7 +724,8 @@ class Task(object):
         else:
             task_pid = self.get_task_pid()
             if task_pid:
-                print "[ {:<6} ] {} is running.".format(task_pid, self.__task_name)
+                print "[ {:<6} ] {} is running.".\
+                    format(task_pid, self.__task_name)
 
 
 class CCompute(Task, CElement):
@@ -771,17 +777,21 @@ class CCompute(Task, CElement):
                     logger.log('[model:compute] infrasim has enabled kvm')
                 else:
                     self.__enable_kvm = False
-                    logger.warning('[model:compute] infrasim can\'t enable kvm on this environment')
+                    logger.warning('[model:compute] infrasim can\'t '
+                                   'enable kvm on this environment')
             else:
                 self.__enable_kvm = False
                 logger.log('[model:compute] infrasim doesn\'t enable kvm')
 
         if 'smbios' in self.__compute:
             self.__smbios = self.__compute['smbios']
-        elif os.path.exists("/usr/local/etc/infrasim/{0}/{0}_smbios.bin".format(self.__vendor_type)):
-            self.__smbios = "/usr/local/etc/infrasim/{0}/{0}_smbios.bin".format(self.__vendor_type)
+        elif os.path.exists("/usr/local/etc/infrasim/{0}/{0}_smbios.bin".
+                                    format(self.__vendor_type)):
+            self.__smbios = "/usr/local/etc/infrasim/{0}/{0}_smbios.bin".\
+                format(self.__vendor_type)
         else:
-            logger.warning('[model:compute] infrasim doesn\'t find proper SMBIOS file')
+            logger.warning('[model:compute] infrasim doesn\'t '
+                           'find proper SMBIOS file')
 
         if 'bios' in self.__compute:
             self.__bios = self.__compute['bios']
@@ -792,12 +802,15 @@ class CCompute(Task, CElement):
         if 'cdrom' in self.__compute:
             self.__cdrom_file = self.__compute['cdrom']
 
-        if 'numa_control' in self.__compute and self.__compute['numa_control']:
+        if 'numa_control' in self.__compute \
+                and self.__compute['numa_control']:
             if os.path.exists("/usr/bin/numactl"):
                 self.set_numactl(NumaCtl())
-                logger.log('[model:compute] infrasim has enabled numa control')
+                logger.log('[model:compute] infrasim has '
+                           'enabled numa control')
             else:
-                logger.log('[model:compute] infrasim can\'t find numactl in this environment')
+                logger.log('[model:compute] infrasim can\'t '
+                           'find numactl in this environment')
 
         cpu_obj = CCPU(self.__compute['cpu'])
         self.__element_list.append(cpu_obj)
@@ -1048,7 +1061,8 @@ class CBMC(Task):
         if 'lancontrol' in self.__bmc:
             self.__lancontrol_script = self.__bmc['lancontrol']
         else:
-            self.__lancontrol_script = "/usr/local/etc/infrasim/script/lancontrol"
+            self.__lancontrol_script \
+                = "/usr/local/etc/infrasim/script/lancontrol"
 
         if 'chassiscontrol' in self.__bmc:
             self.__chassiscontrol_script = self.__bmc['chassiscontrol']
@@ -1256,13 +1270,21 @@ class CNode(object):
                     os.chmod(dst, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
             if not has_option(self.__node, "bmc", "startcmd"):
-                path_startcmd = os.path.join(self.workspace, "script", "startcmd")
+                path_startcmd = os.path.join(self.workspace,
+                                             "script",
+                                             "startcmd")
                 bmc_obj.set_startcmd_script(path_startcmd)
 
             if not has_option(self.__node, "bmc", "chassiscontrol"):
-                path_startcmd = os.path.join(self.workspace, "script", "startcmd")
-                path_stopcmd = os.path.join(self.workspace, "script", "stopcmd")
-                path_resetcmd = os.path.join(self.workspace, "script", "resetcmd")
+                path_startcmd = os.path.join(self.workspace,
+                                             "script",
+                                             "startcmd")
+                path_stopcmd = os.path.join(self.workspace,
+                                            "script",
+                                            "stopcmd")
+                path_resetcmd = os.path.join(self.workspace,
+                                             "script",
+                                             "resetcmd")
                 src = os.path.join(TEMPLATE_ROOT, "script", "chassiscontrol")
                 dst = os.path.join(self.workspace, "script", "chassiscontrol")
                 with open(src, "r") as f:
@@ -1279,10 +1301,16 @@ class CNode(object):
                 bmc_obj.set_chassiscontrol_script(path_chassiscontrol)
 
             if not has_option(self.__node, "bmc", "lancontrol"):
-                os.symlink(os.path.join(TEMPLATE_ROOT, "script", "lancontrol"),
-                           os.path.join(self.workspace, "script", "lancontrol"))
+                os.symlink(os.path.join(TEMPLATE_ROOT,
+                                        "script",
+                                        "lancontrol"),
+                           os.path.join(self.workspace,
+                                        "script",
+                                        "lancontrol"))
 
-                path_lancontrol = os.path.join(self.workspace, "script", "lancontrol")
+                path_lancontrol = os.path.join(self.workspace,
+                                               "script",
+                                               "lancontrol")
                 bmc_obj.set_lancontrol_script(path_lancontrol)
 
             # Render connection port/device
@@ -1478,4 +1506,3 @@ class NumaCtl(object):
                     return returned_cpu_list
 
         return returned_cpu_list
-

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1322,6 +1322,9 @@ class CNode(object):
                 path_resetcmd = os.path.join(self.workspace,
                                              "script",
                                              "resetcmd")
+                path_qemu_pid = os.path.join(self.workspace,
+                                             ".{}-node".
+                                             format(self.get_node_name()))
                 src = os.path.join(TEMPLATE_ROOT, "script", "chassiscontrol")
                 dst = os.path.join(self.workspace, "script", "chassiscontrol")
                 with open(src, "r") as f:
@@ -1329,7 +1332,8 @@ class CNode(object):
                 template = jinja2.Template(src_text)
                 dst_text = template.render(startcmd=path_startcmd,
                                            stopcmd=path_stopcmd,
-                                           resetcmd=path_resetcmd)
+                                           resetcmd=path_resetcmd,
+                                           qemu_pid_file=path_qemu_pid)
                 with open(dst, "w") as f:
                     f.write(dst_text)
                 os.chmod(dst, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -943,14 +943,29 @@ class CBMC(Task):
     def set_config_file(self, dst):
         self.__config_file = dst
 
+    def get_emu_file(self):
+        return self.__emu_file
+
+    def set_emu_file(self, path):
+        self.__emu_file = path
+
     def set_startcmd_script(self, path):
         self.__startcmd_script = path
+
+    def get_startcmd_script(self):
+        return self.__startcmd_script
 
     def set_chassiscontrol_script(self, path):
         self.__chassiscontrol_script = path
 
+    def get_chassiscontrol_script(self):
+        return self.__chassiscontrol_script
+
     def set_lancontrol_script(self, path):
         self.__lancontrol_script = path
+
+    def get_lancontrol_script(self):
+        return self.__lancontrol_script
 
     def precheck(self):
         # check if ipmi_sim exists
@@ -959,6 +974,19 @@ class CBMC(Task):
             self.__bin = ipmi_cmd.strip(os.linesep)
         except CommandRunFailed:
             raise CommandNotFound("/usr/local/bin/ipmi_sim")
+
+        # check script exits
+        if not os.path.exists(self.__lancontrol_script):
+            raise ArgsNotCorrect("Lan control script {} doesn\'t exist".
+                                 format(self.__lancontrol_script))
+
+        if not os.path.exists(self.__chassiscontrol_script):
+            raise ArgsNotCorrect("Chassis control script {} doesn\'t exist".
+                                 format(self.__chassiscontrol_script))
+
+        if not os.path.exists(self.__startcmd_script):
+            raise ArgsNotCorrect("startcmd script {} doesn\'t exist".
+                                 format(self.__chassiscontrol_script))
 
         # check ports are in use
         # check lan interface exists
@@ -1003,9 +1031,6 @@ class CBMC(Task):
             raise ArgsNotCorrect("History FRU is expected to be integer, "
                                  "it's set to {} now".
                                  format(self.__historyfru))
-
-        if not self.__sol_device and not self.get_workspace():
-            raise ArgsNotCorrect("No workspace or serial device is defined")
 
         # check configuration file exists
         if not os.path.isfile(self.__emu_file):
@@ -1060,15 +1085,27 @@ class CBMC(Task):
 
         if 'lancontrol' in self.__bmc:
             self.__lancontrol_script = self.__bmc['lancontrol']
+        elif self.get_workspace():
+            self.__lancontrol_script = os.path.join(self.get_workspace(),
+                                                    "script",
+                                                    "lancontrol")
         else:
             self.__lancontrol_script \
                 = "/usr/local/etc/infrasim/script/lancontrol"
 
         if 'chassiscontrol' in self.__bmc:
             self.__chassiscontrol_script = self.__bmc['chassiscontrol']
+        elif self.get_workspace():
+            self.__chassiscontrol_script = os.path.join(self.get_workspace(),
+                                                        "script",
+                                                        "chassiscontrol")
 
         if 'startcmd' in self.__bmc:
             self.__startcmd_script = self.__bmc['startcmd']
+        elif self.get_workspace():
+            self.__startcmd_script = os.path.join(self.get_workspace(),
+                                                  "script",
+                                                  "startcmd")
 
         if 'startnow' in self.__bmc:
             if self.__bmc['startnow']:

--- a/infrasim/qemu.py
+++ b/infrasim/qemu.py
@@ -48,14 +48,41 @@ def start_qemu(conf_file=VM_DEFAULT_CONFIG):
         with open(conf_file, 'r') as f_yml:
             conf = yaml.load(f_yml)
         compute = CCompute(conf["compute"])
+        node_name = conf["name"] if "name" in conf else "node-0"
+        workspace = "{}/.infrasim/{}".format(os.environ["HOME"], node_name)
+        if not os.path.isdir(workspace):
+            os.mkdir(workspace)
+        path_log = "/var/log/infrasim/{}".format(node_name)
+        if not os.path.isdir(path_log):
+            os.mkdir(path_log)
+
+        # Set attributes
+        compute.set_task_name("{}-node".format(node_name))
+        compute.set_log_path("/var/log/infrasim/{}/qemu.log".
+                             format(node_name))
+        compute.set_workspace("{}/.infrasim/{}".
+                              format(os.environ["HOME"], node_name))
         compute.set_type(conf["type"])
+
+        # Set interface
+        if "type" not in conf:
+            raise ArgsNotCorrect("Can't get infrasim type")
+        else:
+            compute.set_type(conf['type'])
+
+        if "serial_port" in conf:
+            compute.set_port_serial(conf["serial_port"])
+
+        if "bmc_connection_port" in conf:
+            compute.set_port_qemu_ipmi(conf["bmc_connection_port"])
+
         compute.init()
         compute.precheck()
-        cmd = compute.get_commandline()
-        logger.debug(cmd)
-        run_command(cmd+" &", True, None, None)
+        compute.run()
 
         logger.info("qemu start")
+
+        return
     except CommandRunFailed as e:
         logger.error(e.value)
         raise e
@@ -64,12 +91,37 @@ def start_qemu(conf_file=VM_DEFAULT_CONFIG):
         raise e
 
 
-def stop_qemu():
+def stop_qemu(conf_file=VM_DEFAULT_CONFIG):
     try:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.connect(("127.0.0.1",  2345))
-        sock.send("quit\n")
-        sock.close()
+        with open(conf_file, 'r') as f_yml:
+            conf = yaml.load(f_yml)
+        compute = CCompute(conf["compute"])
+        node_name = conf["name"] if "name" in conf else "node-0"
+
+        # Set attributes
+        compute.set_task_name("{}-node".format(node_name))
+        compute.set_log_path("/var/log/infrasim/{}/qemu.log".
+                             format(node_name))
+        compute.set_workspace("{}/.infrasim/{}".
+                              format(os.environ["HOME"], node_name))
+        compute.set_type(conf["type"])
+
+        # Set interface
+        if "type" not in conf:
+            raise ArgsNotCorrect("Can't get infrasim type")
+        else:
+            compute.set_type(conf['type'])
+
+        if "serial_port" in conf:
+            compute.set_port_serial(conf["serial_port"])
+
+        if "bmc_connection_port" in conf:
+            compute.set_port_qemu_ipmi(conf["bmc_connection_port"])
+
+        compute.init()
+        compute.terminate()
+
+        logger.info("qemu stopped")
     except Exception, e:
-        pass
-    logger.info("qemu stopped")
+        logger.error(e.value)
+        raise e

--- a/infrasim/qemu.py
+++ b/infrasim/qemu.py
@@ -43,17 +43,17 @@ def stop_macvtap(eth):
         raise e
 
 
-def start_qemu(conf=VM_DEFAULT_CONFIG):
+def start_qemu(conf_file=VM_DEFAULT_CONFIG):
     try:
-        with open(conf, 'r') as f_yml:
+        with open(conf_file, 'r') as f_yml:
             conf = yaml.load(f_yml)
         compute = CCompute(conf["compute"])
         compute.set_type(conf["type"])
         compute.init()
         compute.precheck()
-        cmd = "{} 2>/var/log/qemu.log &".format(compute.get_commandline())
+        cmd = compute.get_commandline()
         logger.debug(cmd)
-        run_command(cmd, True, None, None)
+        run_command(cmd+" &", True, None, None)
 
         logger.info("qemu start")
     except CommandRunFailed as e:

--- a/infrasim/socat.py
+++ b/infrasim/socat.py
@@ -24,9 +24,9 @@ def status_socat():
         print "Inrasim Socat service is stopped"
 
 
-def start_socat(conf=VM_DEFAULT_CONFIG):
+def start_socat(conf_file=VM_DEFAULT_CONFIG):
     try:
-        with open(conf, 'r') as f_yml:
+        with open(conf_file, 'r') as f_yml:
             conf = yaml.load(f_yml)
 
         socat = CSocat()
@@ -39,9 +39,9 @@ def start_socat(conf=VM_DEFAULT_CONFIG):
 
         socat.init()
         socat.precheck()
-        cmd = "{} &".format(socat.get_commandline())
+        cmd = socat.get_commandline()
 
-        run_command(cmd, True, None, None)
+        run_command(cmd+" &", True, None, None)
         time.sleep(3)
         logger.info("socat start")
     except CommandRunFailed as e:

--- a/infrasim/socat.py
+++ b/infrasim/socat.py
@@ -4,7 +4,7 @@
 import os
 import time
 import yaml
-from infrasim.model import CSocat
+from infrasim.model import CSocat, CNode
 from . import run_command, logger, CommandNotFound, CommandRunFailed, VM_DEFAULT_CONFIG
 
 
@@ -29,6 +29,11 @@ def start_socat(conf_file=VM_DEFAULT_CONFIG):
         with open(conf_file, 'r') as f_yml:
             conf = yaml.load(f_yml)
 
+        node = CNode(conf)
+        if "name" in conf:
+            node.set_node_name(conf["name"])
+        node.init_workspace()
+
         socat = CSocat()
         # Read SOL device, serial port from conf
         # and set to socat
@@ -37,6 +42,7 @@ def start_socat(conf_file=VM_DEFAULT_CONFIG):
         if "serial_port" in conf:
             socat.set_port_serial(conf["serial_port"])
 
+        socat.set_workspace(node.workspace)
         socat.init()
         socat.precheck()
         cmd = socat.get_commandline()
@@ -48,7 +54,7 @@ def start_socat(conf_file=VM_DEFAULT_CONFIG):
         raise e
 
 
-def stop_socat():
+def stop_socat(conf_file=VM_DEFAULT_CONFIG):
     socat_stop_cmd = "pkill socat"
     try:
         run_command(socat_stop_cmd, True, None, None)

--- a/test/functional/test_configuration_change.py
+++ b/test/functional/test_configuration_change.py
@@ -33,12 +33,16 @@ class test_compute_configuration_change(unittest.TestCase):
         os.system("touch test.yml")
         with open(VM_DEFAULT_CONFIG, 'r') as f_yml:
             self.conf = yaml.load(f_yml)
+        self.conf["name"] = ".test"
+        node = model.CNode(self.conf)
+        node.set_node_name(self.conf["name"])
+        node.init_workspace()
 
     def tearDown(self):
         qemu.stop_qemu("test.yml")
         self.conf = None
         os.system("rm -rf test.yml")
-        os.system("rm -rf {}/.infrasim/node-0/".format(os.environ["HOME"]))
+        os.system("rm -rf {}/.infrasim/.test/".format(os.environ["HOME"]))
 
     def test_set_vcpu(self):
         self.conf["compute"]["cpu"]["quantities"] = 8
@@ -225,9 +229,10 @@ class test_connection(unittest.TestCase):
         str_result = run_command(PS_QEMU, True,
                                  subprocess.PIPE, subprocess.PIPE)[1]
         assert "qemu-system-x86_64" in str_result
-        assert "-smbios file=/usr/local/etc/infrasim/" \
-               "dell_c6320/dell_c6320_smbios.bin" in str_result
+        assert "-smbios file={}/.infrasim/test/data/dell_c6320_smbios.bin".\
+            format(os.environ["HOME"]) in str_result
 
         str_result = run_command(PS_IPMI, True,
                                  subprocess.PIPE, subprocess.PIPE)[1]
-        assert "dell_c6320.emu" in str_result
+        assert "-f {}/.infrasim/test/data/dell_c6320.emu".\
+            format(os.environ["HOME"]) in str_result

--- a/test/functional/test_configuration_change.py
+++ b/test/functional/test_configuration_change.py
@@ -9,9 +9,12 @@ import yaml
 from infrasim import qemu
 from infrasim import ipmi
 from infrasim import socat
+from infrasim import model
 
 VM_DEFAULT_CONFIG = "/etc/infrasim/infrasim.yml"
-CMD = "ps ax | grep qemu"
+PS_QEMU = "ps ax | grep qemu"
+PS_IPMI = "ps ax | grep ipmi"
+PS_SOCAT = "ps ax | grep socat"
 
 
 def run_command(cmd="", shell=True, stdout=None, stderr=None):
@@ -32,9 +35,8 @@ class test_compute_configuration_change(unittest.TestCase):
             self.conf = yaml.load(f_yml)
 
     def tearDown(self):
+        qemu.stop_qemu("test.yml")
         self.conf = None
-        cmd = 'pkill qemu'
-        run_command(cmd, True, subprocess.PIPE, subprocess.PIPE)
         os.system("rm -rf test.yml")
 
     def test_set_vcpu(self):
@@ -42,7 +44,7 @@ class test_compute_configuration_change(unittest.TestCase):
         with open("test.yml", "w") as yaml_file:
             yaml.dump(self.conf, yaml_file, default_flow_style=False)
         qemu.start_qemu("test.yml")
-        str_result = run_command(CMD, True,
+        str_result = run_command(PS_QEMU, True,
                                  subprocess.PIPE, subprocess.PIPE)[1]
         assert "qemu-system-x86_64" in str_result
         assert "-smp 8" in str_result
@@ -52,32 +54,20 @@ class test_compute_configuration_change(unittest.TestCase):
         with open("test.yml", "w") as yaml_file:
             yaml.dump(self.conf, yaml_file, default_flow_style=False)
         qemu.start_qemu("test.yml")
-        str_result = run_command(CMD, True,
+        str_result = run_command(PS_QEMU, True,
                                  subprocess.PIPE, subprocess.PIPE)[1]
         assert "qemu-system-x86_64" in str_result
         assert "-cpu IvyBridge" in str_result
 
-    def test_set_node_name(self):
-        self.conf["compute"]["name"] = "dell_c6320"
-        with open("test.yml", "w") as yaml_file:
-            yaml.dump(self.conf, yaml_file, default_flow_style=False)
-        qemu.start_qemu("test.yml")
-        str_result = run_command(CMD, True,
-                                 subprocess.PIPE, subprocess.PIPE)[1]
-        assert "qemu-system-x86_64" in str_result
-        assert "-name dell_c6320" in str_result
-        assert "-smbios file=/usr/local/etc/infrasim/" \
-               "dell_c6320/dell_c6320_smbios.bin" in str_result
-
     def test_set_memory_capacity(self):
-        self.conf["compute"]["memory"]["size"] = 2048
+        self.conf["compute"]["memory"]["size"] = 1536
         with open("test.yml", "w") as yaml_file:
             yaml.dump(self.conf, yaml_file, default_flow_style=False)
         qemu.start_qemu("test.yml")
-        str_result = run_command(CMD, True,
+        str_result = run_command(PS_QEMU, True,
                                  subprocess.PIPE, subprocess.PIPE)[1]
         assert "qemu-system-x86_64" in str_result
-        assert "-m 2048" in str_result
+        assert "-m 1536" in str_result
 
     def test_set_disk_drive(self):
         self.conf["compute"]["storage_backend"] = [{
@@ -90,7 +80,7 @@ class test_compute_configuration_change(unittest.TestCase):
         with open("test.yml", "w") as yaml_file:
             yaml.dump(self.conf, yaml_file, default_flow_style=False)
         qemu.start_qemu("test.yml")
-        str_result = run_command(CMD, True,
+        str_result = run_command(PS_QEMU, True,
                                  subprocess.PIPE, subprocess.PIPE)[1]
         assert "qemu-system-x86_64" in str_result
         assert ".infrasim/sda.img,format=qcow2" in str_result
@@ -103,21 +93,24 @@ class test_bmc_configuration_change(unittest.TestCase):
         os.system("touch test.yml")
         with open(VM_DEFAULT_CONFIG, 'r') as f_yml:
             self.conf = yaml.load(f_yml)
+        self.conf["name"] = "test"
 
     def tearDown(self):
+        node = model.CNode(self.conf)
+        node.init()
+        node.stop()
+        node.terminate_workspace()
         self.conf = None
-        qemu.stop_qemu()
-        ipmi.stop_ipmi()
-        socat.stop_socat()
         os.system("rm -rf test.yml")
 
     def test_set_bmc_iol_port(self):
         self.conf["bmc"] = {}
         self.conf["bmc"]["ipmi_over_lan_port"] = 624
-        with open("test.yml", "w") as yaml_file:
-            yaml.dump(self.conf, yaml_file, default_flow_style=False)
-        socat.start_socat()
-        ipmi.start_ipmi("test.yml")
+
+        node = model.CNode(self.conf)
+        node.init()
+        node.precheck()
+        node.start()
 
         cmd = 'ipmitool -H 127.0.0.1 -U admin -P admin -p 624 -I lanplus ' \
               'raw 0x06 0x01'
@@ -132,3 +125,109 @@ class test_bmc_configuration_change(unittest.TestCase):
                                          stdout=subprocess.PIPE,
                                          stderr=subprocess.PIPE)
         assert returncode != 0
+
+
+class test_connection(unittest.TestCase):
+
+    def setUp(self):
+        os.system("touch test.yml")
+        with open(VM_DEFAULT_CONFIG, 'r') as f_yml:
+            self.conf = yaml.load(f_yml)
+        self.conf["name"] = "test"
+        self.bmc_conf = os.path.join(os.environ["HOME"], ".infrasim",
+                                     "test", "data", "vbmc.conf")
+
+    def tearDown(self):
+        node = model.CNode(self.conf)
+        node.init()
+        node.stop()
+        node.terminate_workspace()
+        self.conf = None
+        os.system("rm -rf test.yml")
+
+    def test_set_sol_device(self):
+        temp_sol_device = "{}/.infrasim/pty_test".format(os.environ['HOME'])
+        self.conf["sol_device"] = temp_sol_device
+
+        node = model.CNode(self.conf)
+        node.init()
+        node.precheck()
+        node.start()
+
+        str_result = run_command(PS_SOCAT, True,
+                                 subprocess.PIPE, subprocess.PIPE)[1]
+        assert "pty,link={},waitslave".format(temp_sol_device) in str_result
+
+        with open(self.bmc_conf, "r") as fp:
+            bmc_conf = fp.read()
+        assert 'sol "{}" 115200', format(temp_sol_device) in bmc_conf
+
+    def test_set_ipmi_console_port(self):
+        self.conf["ipmi_console_port"] = 9100
+
+        node = model.CNode(self.conf)
+        node.init()
+        node.precheck()
+        node.start()
+
+        with open(self.bmc_conf, "r") as fp:
+            bmc_conf = fp.read()
+        assert 'console 0.0.0.0 9100' in bmc_conf
+
+        print '\033[93m{}\033[0m'.\
+            format("Not implemented: "
+                   "test if ipmi-console connect to same port")
+
+    def test_set_bmc_connection_port(self):
+        self.conf["bmc_connection_port"] = 9102
+
+        node = model.CNode(self.conf)
+        node.init()
+        node.precheck()
+        node.start()
+
+        with open(self.bmc_conf, "r") as fp:
+            bmc_conf = fp.read()
+        assert 'serial 15 0.0.0.0 9102 codec VM ipmb 0x20' in bmc_conf
+
+        str_result = run_command(PS_QEMU, True,
+                                 subprocess.PIPE, subprocess.PIPE)[1]
+        assert "port=9102" in str_result
+
+    def test_set_serial_port(self):
+        self.conf["serial_port"] = 9103
+
+        node = model.CNode(self.conf)
+        node.init()
+        node.precheck()
+        node.start()
+
+        with open(self.bmc_conf, "r") as fp:
+            bmc_conf = fp.read()
+
+        str_result = run_command(PS_QEMU, True,
+                                 subprocess.PIPE, subprocess.PIPE)[1]
+        assert "-serial mon:udp:127.0.0.1:9103,nowait" in str_result
+
+        str_result = run_command(PS_SOCAT, True,
+                                 subprocess.PIPE, subprocess.PIPE)[1]
+        assert "udp-listen:9103,reuseaddr" in str_result
+
+    def test_set_node_type(self):
+        self.conf["type"] = "dell_c6320"
+
+        node = model.CNode(self.conf)
+        node.init()
+        node.precheck()
+        node.start()
+
+        str_result = run_command(PS_QEMU, True,
+                                 subprocess.PIPE, subprocess.PIPE)[1]
+        assert "qemu-system-x86_64" in str_result
+        assert "-smbios file=/usr/local/etc/infrasim/" \
+               "dell_c6320/dell_c6320_smbios.bin" in str_result
+
+        str_result = run_command(PS_IPMI, True,
+                                 subprocess.PIPE, subprocess.PIPE)[1]
+        assert "dell_c6320.emu" in str_result
+

--- a/test/functional/test_configuration_change.py
+++ b/test/functional/test_configuration_change.py
@@ -38,6 +38,7 @@ class test_compute_configuration_change(unittest.TestCase):
         qemu.stop_qemu("test.yml")
         self.conf = None
         os.system("rm -rf test.yml")
+        os.system("rm -rf {}/.infrasim/node-0/".format(os.environ["HOME"]))
 
     def test_set_vcpu(self):
         self.conf["compute"]["cpu"]["quantities"] = 8

--- a/test/functional/test_configuration_change.py
+++ b/test/functional/test_configuration_change.py
@@ -230,4 +230,3 @@ class test_connection(unittest.TestCase):
         str_result = run_command(PS_IPMI, True,
                                  subprocess.PIPE, subprocess.PIPE)[1]
         assert "dell_c6320.emu" in str_result
-

--- a/test/functional/test_ipmi_chassis.py
+++ b/test/functional/test_ipmi_chassis.py
@@ -13,10 +13,9 @@ Test ipmitool chassis control commands:
 
 import unittest
 import time
+import yaml
 
-from infrasim import qemu
-from infrasim import ipmi
-from infrasim import socat
+from infrasim import model
 from infrasim import run_command
 
 # command prefix for test cases
@@ -37,14 +36,24 @@ power_reset_cmd = cmd_prefix + 'power reset'
 
 class test_ipmi_command_chassis_control(unittest.TestCase):
     def setUp(self):
-        socat.start_socat()
-        ipmi.start_ipmi()
-        time.sleep(3)
+        node_info = {}
+        with open("/etc/infrasim/infrasim.yml", 'r') as f_yml:
+            node_info = yaml.load(f_yml)
+        node_info["name"] = "test"
+        node = model.CNode(node_info)
+        node.init()
+        node.precheck()
+        node.start()
 
     def tearDown(self):
-        qemu.stop_qemu()
-        ipmi.stop_ipmi()
-        socat.stop_socat()
+        node_info = {}
+        with open("/etc/infrasim/infrasim.yml", 'r') as f_yml:
+            node_info = yaml.load(f_yml)
+        node_info["name"] = "test"
+        node = model.CNode(node_info)
+        node.init()
+        node.stop()
+        node.terminate_workspace()
 
     def test_chassis_power_off_on(self):
         try:
@@ -74,7 +83,7 @@ class test_ipmi_command_chassis_control(unittest.TestCase):
         try:
             pid_before = run_command(pid_cmd)[1]
             run_command(power_cycle_cmd)
-            time.sleep(3)
+            time.sleep(5)
             qemu_output = run_command(test_cmd)[1]
             assert 'qemu-system-x86_64' in qemu_output
             pid_after = run_command(pid_cmd)[1]
@@ -87,7 +96,7 @@ class test_ipmi_command_chassis_control(unittest.TestCase):
         try:
             pid_before = run_command(pid_cmd)[1]
             run_command(power_reset_cmd)
-            time.sleep(3)
+            time.sleep(5)
             qemu_output = run_command(test_cmd)[1]
             assert 'qemu-system-x86_64' in qemu_output
             pid_after = run_command(pid_cmd)[1]

--- a/test/functional/test_ipmi_command_response.py
+++ b/test/functional/test_ipmi_command_response.py
@@ -17,9 +17,8 @@ import os
 import subprocess
 import re
 import time
-from infrasim import qemu
-from infrasim import ipmi
-from infrasim import socat
+import yaml
+from infrasim import model
 from infrasim import CommandRunFailed
 
 # ipmitool commands to test
@@ -50,15 +49,25 @@ class test_ipmicommand_response(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        socat.start_socat()
-        ipmi.start_ipmi()
-        time.sleep(3)
+        node_info = {}
+        with open("/etc/infrasim/infrasim.yml", 'r') as f_yml:
+            node_info = yaml.load(f_yml)
+        node_info["name"] = "test"
+        node = model.CNode(node_info)
+        node.init()
+        node.precheck()
+        node.start()
 
     @classmethod
     def tearDownClass(cls):
-        qemu.stop_qemu()
-        ipmi.stop_ipmi()
-        socat.stop_socat()
+        node_info = {}
+        with open("/etc/infrasim/infrasim.yml", 'r') as f_yml:
+            node_info = yaml.load(f_yml)
+        node_info["name"] = "test"
+        node = model.CNode(node_info)
+        node.init()
+        node.stop()
+        node.terminate_workspace()
 
     def test_fru_print(self):
         try:

--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -84,6 +84,7 @@ class test_ipmi_console(unittest.TestCase):
         qemu.stop_qemu()
         ipmi.stop_ipmi()
         socat.stop_socat()
+        os.system("rm -rf {}/.infrasim/node-0/".format(os.environ["HOME"]))
 
     def test_sensor_accessibility(self):
         self.channel.send('sensor info\n')

--- a/test/functional/test_serial.py
+++ b/test/functional/test_serial.py
@@ -27,6 +27,7 @@ class test_serial(unittest.TestCase):
     def tearDown(self):
         self.conf = None
         socat.stop_socat()
+        os.system("rm -rf {}/.infrasim/node-0/".format(os.environ["HOME"]))
         os.system("rm -rf test.yml")
 
     def test_socat_create_serial_device_file(self):

--- a/test/unit/test_core_process.py
+++ b/test/unit/test_core_process.py
@@ -14,8 +14,27 @@ Check:
 from infrasim import qemu
 from infrasim import ipmi
 from infrasim import socat
+from infrasim import model
+from infrasim import VM_DEFAULT_CONFIG
 import time
-from nose.tools import assert_raises
+import yaml
+import os
+
+
+def setUp():
+    workspace = "{}/.infrasim/node-0".format(os.environ["HOME"])
+    if os.path.exists(workspace):
+        os.system("rm -rf {}".format(workspace))
+    with open(VM_DEFAULT_CONFIG, 'r') as f_yml:
+        conf = yaml.load(f_yml)
+    node = model.CNode(conf)
+    node.init_workspace()
+
+
+def tearDown():
+    workspace = "{}/.infrasim/node-0".format(os.environ["HOME"])
+    if os.path.exists(workspace):
+        os.system("rm -rf {}".format(workspace))
 
 
 def test_qemu_exist():
@@ -45,8 +64,7 @@ def test_socat_exist():
 def test_socat_process_start():
     try:
         socat.start_socat()
-        ipmi.start_ipmi()
-        time.sleep(3)
+        time.sleep(2)
         socat.status_socat()
         assert True
     except:
@@ -55,6 +73,8 @@ def test_socat_process_start():
 
 def test_ipmi_process_start():
     try:
+        ipmi.start_ipmi()
+        time.sleep(2)
         ipmi.status_ipmi()
         assert True
     except:

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -11,6 +11,7 @@ from infrasim import VM_DEFAULT_CONFIG
 
 
 class qemu_functions(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         os.system("touch test.yml")
@@ -238,6 +239,38 @@ class qemu_functions(unittest.TestCase):
         except:
             assert False
 
+    def test_set_smbios(self):
+        with open("/etc/infrasim/infrasim.yml", "r") as f_yml:
+            compute_info = yaml.load(f_yml)["compute"]
+        compute_info["smbios"] = "/etc/infrasim/test.smbios"
+
+        compute = model.CCompute(compute_info)
+        compute.init()
+        assert compute.get_smbios() == "/etc/infrasim/test.smbios"
+
+    def test_set_smbios_without_workspace(self):
+        with open("/etc/infrasim/infrasim.yml", "r") as f_yml:
+            compute_info = yaml.load(f_yml)["compute"]
+
+        compute = model.CCompute(compute_info)
+        compute.set_type("s2600kp")
+        compute.init()
+        assert compute.get_smbios() == \
+            "/usr/local/etc/infrasim/s2600kp/s2600kp_smbios.bin"
+
+    def test_set_smbios_with_type_and_workspace(self):
+        with open("/etc/infrasim/infrasim.yml", "r") as f_yml:
+            compute_info = yaml.load(f_yml)["compute"]
+        workspace = os.path.join(os.environ["HOME"], ".infrasim", ".test")
+
+        compute = model.CCompute(compute_info)
+        compute.set_type("s2600kp")
+        compute.set_workspace(workspace)
+        compute.init()
+        assert compute.get_smbios() == os.path.join(workspace,
+                                                    "data",
+                                                    "s2600kp_smbios.bin")
+
 
 class bmc_configuration(unittest.TestCase):
 
@@ -288,6 +321,7 @@ class bmc_configuration(unittest.TestCase):
         bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
+        bmc.precheck()
 
         with open(bmc.get_config_file(), 'r') as fp:
             for line in fp.readlines():
@@ -306,6 +340,7 @@ class bmc_configuration(unittest.TestCase):
         bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
+        bmc.precheck()
 
         with open(bmc.get_config_file(), 'r') as fp:
             if "startnow true" in fp.read():
@@ -323,6 +358,7 @@ class bmc_configuration(unittest.TestCase):
         bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
+        bmc.precheck()
 
         with open(bmc.get_config_file(), 'r') as fp:
             if "startnow false" in fp.read():
@@ -340,6 +376,7 @@ class bmc_configuration(unittest.TestCase):
         bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
+        bmc.precheck()
 
         with open(bmc.get_config_file(), 'r') as fp:
             if "poweroff_wait 0" in fp.read():
@@ -393,6 +430,7 @@ class bmc_configuration(unittest.TestCase):
         bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
+        bmc.precheck()
 
         with open(bmc.get_config_file(), 'r') as fp:
             if "historyfru=11" in fp.read():
@@ -446,6 +484,7 @@ class bmc_configuration(unittest.TestCase):
         bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
+        bmc.precheck()
 
         with open(bmc.get_config_file(), 'r') as fp:
             if "kill_wait 0" in fp.read():
@@ -500,6 +539,7 @@ class bmc_configuration(unittest.TestCase):
         bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
+        bmc.precheck()
 
         credential = "user 2 true  \"test_user\" \"test_password\" " \
                      "admin    10       none md2 md5 straight"
@@ -597,6 +637,7 @@ class bmc_configuration(unittest.TestCase):
         bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
+        bmc.precheck()
 
         with open(bmc.get_config_file(), 'r') as fp:
             if "addr :: 624" in fp.read():

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -3,9 +3,11 @@
 
 import os
 import unittest
+import yaml
 from infrasim import ArgsNotCorrect
 from infrasim import model
 from infrasim import socat
+from infrasim import VM_DEFAULT_CONFIG
 
 
 class qemu_functions(unittest.TestCase):
@@ -236,22 +238,33 @@ class qemu_functions(unittest.TestCase):
         except:
             assert False
 
+
 class bmc_configuration(unittest.TestCase):
 
-    VBMC_CONF = "/etc/infrasim/vbmc.conf"
+    WORKSPACE = "{}/.infrasim/.test".format(os.environ["HOME"])
 
     @classmethod
     def setUpClass(cls):
-        socat.stop_socat()
-        socat.start_socat()
-        os.mkdir("{}/.infrasim/.test".format(os.environ["HOME"]))
-        os.mkdir("{}/.infrasim/.test/data".format(os.environ["HOME"]))
-        os.system("touch {}/.infrasim/.test/data/vbmc.conf")
+        with open(VM_DEFAULT_CONFIG, 'r') as f_yml:
+            conf = yaml.load(f_yml)
+        conf["name"] = ".test"
+        with open("test.yml", 'w') as f_yml:
+            yaml.dump(conf, f_yml, default_flow_style=False)
+
+        cls.node = model.CNode(conf)
+        cls.node.set_node_name(".test")
+        cls.node.init_workspace()
+        socat.start_socat("test.yml")
 
     @classmethod
     def tearDownClass(cls):
-        os.system("rm -rf {}/.infrasim/.test".format(os.environ["HOME"]))
-        socat.stop_socat()
+        socat.stop_socat("test.yml")
+        with open("test.yml", 'r') as f_yml:
+            conf = yaml.load(f_yml)
+        cls.node = model.CNode(conf)
+        cls.node.init()
+        cls.node.terminate_workspace()
+        os.system("rm test.yml")
 
     def test_set_bmc_type(self):
         bmc = model.CBMC()
@@ -261,7 +274,6 @@ class bmc_configuration(unittest.TestCase):
                           "s2600kp", "s2600tp", "s2600wtt"]:
             bmc.set_type(node_type)
             bmc.init()
-            bmc.precheck()
             cmd = bmc.get_commandline()
             assert "/usr/local/etc/infrasim/{0}/{0}.emu".format(node_type) \
                    in cmd
@@ -273,6 +285,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -290,6 +303,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -306,6 +320,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -322,6 +337,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -338,6 +354,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -355,6 +372,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -372,6 +390,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -388,6 +407,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -405,6 +425,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -422,6 +443,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -438,6 +460,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -455,6 +478,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -473,6 +497,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -494,6 +519,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
         bmc.precheck()
@@ -511,6 +537,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -531,6 +558,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
         bmc.precheck()
@@ -548,6 +576,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.set_config_file(fn)
 
@@ -565,6 +594,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -581,6 +611,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 
@@ -599,6 +630,7 @@ class bmc_configuration(unittest.TestCase):
 
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
         bmc.init()
         bmc.write_bmc_config()
 

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -244,9 +244,13 @@ class bmc_configuration(unittest.TestCase):
     def setUpClass(cls):
         socat.stop_socat()
         socat.start_socat()
+        os.mkdir("{}/.infrasim/.test".format(os.environ["HOME"]))
+        os.mkdir("{}/.infrasim/.test/data".format(os.environ["HOME"]))
+        os.system("touch {}/.infrasim/.test/data/vbmc.conf")
 
     @classmethod
     def tearDownClass(cls):
+        os.system("rm -rf {}/.infrasim/.test".format(os.environ["HOME"]))
         socat.stop_socat()
 
     def test_set_bmc_type(self):
@@ -270,63 +274,13 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         with open(bmc.get_config_file(), 'r') as fp:
             for line in fp.readlines():
                 if "lan_config_program" in line and "lo" in line:
                     assert True
                     return
-            assert False
-
-    def test_set_invalid_lan_control_script(self):
-        bmc_info = {
-            # Which doesn't exist
-            "lancontrol": "/etc/infrasim/lancontrol"
-        }
-
-        bmc = model.CBMC(bmc_info)
-        bmc.set_type("quanta_d51")
-        bmc.init()
-
-        try:
-            bmc.precheck()
-        except ArgsNotCorrect, e:
-            assert "Lan control script" in str(e)
-        else:
-            assert False
-
-    def test_set_invalid_chassis_control_script(self):
-        bmc_info = {
-            # Which doesn't exist
-            "chassiscontrol": "/etc/infrasim/chassiscontrol"
-        }
-
-        bmc = model.CBMC(bmc_info)
-        bmc.set_type("quanta_d51")
-        bmc.init()
-
-        try:
-            bmc.precheck()
-        except ArgsNotCorrect, e:
-            assert "Chassis control script" in str(e)
-        else:
-            assert False
-
-    def test_set_invalid_startcmd_script(self):
-        bmc_info = {
-            # Which doesn't exist
-            "startcmd": "/etc/infrasim/startcmd"
-        }
-
-        bmc = model.CBMC(bmc_info)
-        bmc.set_type("quanta_d51")
-        bmc.init()
-
-        try:
-            bmc.precheck()
-        except ArgsNotCorrect, e:
-            assert "startcmd script" in str(e)
-        else:
             assert False
 
     def test_set_startnow_true(self):
@@ -337,6 +291,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         with open(bmc.get_config_file(), 'r') as fp:
             if "startnow true" in fp.read():
@@ -352,6 +307,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         with open(bmc.get_config_file(), 'r') as fp:
             if "startnow false" in fp.read():
@@ -367,6 +323,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         with open(bmc.get_config_file(), 'r') as fp:
             if "poweroff_wait 0" in fp.read():
@@ -382,6 +339,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         try:
             bmc.precheck()
@@ -398,6 +356,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         try:
             bmc.precheck()
@@ -414,6 +373,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         with open(bmc.get_config_file(), 'r') as fp:
             if "historyfru=11" in fp.read():
@@ -429,6 +389,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         try:
             bmc.precheck()
@@ -445,6 +406,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         try:
             bmc.precheck()
@@ -461,6 +423,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         with open(bmc.get_config_file(), 'r') as fp:
             if "kill_wait 0" in fp.read():
@@ -476,6 +439,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         try:
             bmc.precheck()
@@ -492,6 +456,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         try:
             bmc.precheck()
@@ -509,6 +474,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         credential = "user 2 true  \"test_user\" \"test_password\" " \
                      "admin    10       none md2 md5 straight"
@@ -529,6 +495,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
         bmc.precheck()
 
         assert "-f {}".format(fn) in bmc.get_commandline()
@@ -545,6 +512,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         try:
             bmc.precheck()
@@ -564,6 +532,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
         bmc.precheck()
 
         assert "-c {}".format(fn) in bmc.get_commandline()
@@ -580,6 +549,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.set_config_file(fn)
 
         try:
             bmc.precheck()
@@ -596,6 +566,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         with open(bmc.get_config_file(), 'r') as fp:
             if "addr :: 624" in fp.read():
@@ -611,6 +582,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         try:
             bmc.precheck()
@@ -628,6 +600,7 @@ class bmc_configuration(unittest.TestCase):
         bmc = model.CBMC(bmc_info)
         bmc.set_type("quanta_d51")
         bmc.init()
+        bmc.write_bmc_config()
 
         try:
             bmc.precheck()

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -652,4 +652,4 @@ class socat_configuration(unittest.TestCase):
         cmd = socat_obj.get_commandline()
 
         assert "pty,link=/etc/infrasim/pty0,waitslave" in cmd
-        assert "udp-listen:9003,reuseaddr,fork" in cmd
+        assert "udp-listen:9003,reuseaddr" in cmd


### PR DESCRIPTION
[  ] Enable CBMC
[  ] Update jinja template of vbmc.conf with more customization
[  ] Enable socat
[->] Enable task schedule to start/stop socat, bmc, qemu
[->] Scrub infrasim.yml to avoid duplicated definition

**Node wise customization**
Support these attributes defined in yml

    node_id             # default is 0
    type
    sol_device          # e.g. pty0: ipmi_sim <> socat
    ipmi_console_port   # e.g. 9000: ipmi_sim <> ipmi-console
    bmc_connection_port # e.g. 9002: ipmi_sim <> qemu
    serial_port         # e.g. 9003: socat <> qemu

    compute:
        numa_control    # True or false to enable numa control

Enable attributes init in CNode.init()

**Enable workspace for a specific node: <HOME>/.infrasim/<node_name>**

    .infrasim/<node_name>    # Root folder
        data                 # Data folder
            infrasim.yml     # Save runtime infrasim.yml
            vbmc.conf        # Render template with data from infrasim.yml
            vbmc.emu         # Emulation data
            bios.bin         # BIOS
        script               # Script folder
            chassiscontrol
            lancontrol
            startcmd
            stopcmd
            resetcmd
        .pty0                # Serial device, created by socat, not here
        .<node_name>-socat   # pid file of socat
        .<node_name>-ipmi    # pid file of ipmi
        .<node_name>-qemu    # pid file of qemu

**What's done in init_workspace()**

- Create workspace
- Create log folder
- Create sub folder
- Save infrasim.yml
- Render vbmc.conf, render scripts
- Move emulation data, update identifiers, e.g. S/N
- Move bios.bin

**Fixed minor bugs**
1. NotImplemented should be NotImplementedError
2. Join numa control with qemu commandline should use list
3. Remove socat option "fork" to avoid socat's fork when qemu
is trying to connect, or user shall see multiple socat process
