### PR TITLE
enhance/remove_crypto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ nose==1.3.7
 paramiko==2.0.1
 pyasn1==0.1.9
 pycparser==2.14
-pycrypto==2.6.1
 six==1.10.0
 ssh==1.8.0
 coverage >=3.6


### PR DESCRIPTION
One test on CEC machine with 16.04 ubuntu fail to install python
library cryptography.
Since infrasim-compute has no dependency on pycrypto, here I
remove this library from requirements.