### PR TITLE
- Get vBMC credential from IPMI SIM for user when running ipmitool co…

### DIFF
--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -16,7 +16,9 @@ from infrasim import qemu
 from infrasim import ipmi
 from infrasim import socat
 from infrasim import console
+from infrasim import config
 import threading
+import yaml
 
 
 def run_command(cmd="", shell=True, stdout=None, stderr=None):
@@ -73,12 +75,26 @@ class test_ipmi_console(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        socat.start_socat()
-        ipmi.start_ipmi()
+        node_info = {}
+        with open(config.infrasim_initial_config, 'r') as f_yml:
+            node_info = yaml.load(f_yml)
+        node_info["name"] = "test"
+
+        with open("/tmp/test.yaml", "w") as f:
+            yaml.dump(node_info, f, default_flow_style=False)
+
+        socat.start_socat(conf_file="/tmp/test.yaml")
+        ipmi.start_ipmi(conf_file="/tmp/test.yaml")
+        # Wait ipmi_sim sever coming up.
+        # FIXME: good way???
+        time.sleep(5)
         ipmi_console_thread = threading.Thread(target=console.start, args=())
         ipmi_console_thread.setDaemon(True)
         ipmi_console_thread.start()
-        time.sleep(5)
+        # Wait SSH server coming up
+        # FIXME: Need a good way to check if SSH server is listening
+        # on port 9300
+        time.sleep(20)
         cls.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         cls.ssh.connect('127.0.0.1', username='', password='', port=9300)
         cls.channel = cls.ssh.invoke_shell()
@@ -88,10 +104,10 @@ class test_ipmi_console(unittest.TestCase):
         cls.channel.send('quit\n')
         cls.channel.close()
         cls.ssh.close()
-        qemu.stop_qemu()
-        ipmi.stop_ipmi()
-        socat.stop_socat()
-        os.system("rm -rf {}/.infrasim/node-0/".format(os.environ["HOME"]))
+        qemu.stop_qemu(conf_file="/tmp/test.yaml")
+        ipmi.stop_ipmi(conf_file="/tmp/test.yaml")
+        socat.stop_socat(conf_file="/tmp/test.yaml")
+        os.system("rm -rf {}/.infrasim/test/".format(os.environ["HOME"]))
 
     def test_sensor_accessibility(self):
         self.channel.send('sensor info\n')


### PR DESCRIPTION
…mmand

- Fix the test_ipmi_console function test errors

error messages:
-------------------- >> begin captured logging << --------------------
root: INFO: socat start
root: DEBUG: ipmi_sim -c /home/robert/.infrasim/node-0/data/vbmc.conf -f
/home/robert/.infrasim/node-0/data/quanta_d51.emu -n -s /var/tmp
root: INFO: bmc start
ipmi_sim: ERROR: Unable to connect lanserv at 9000: [Errno 111]
Connection refused
--------------------- >> end captured logging << ---------------------