### PR TITLE
Features/update init

### DIFF
--- a/infrasim/__init__.py
+++ b/infrasim/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import logging
 import subprocess
 

--- a/infrasim/console.py
+++ b/infrasim/console.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 '''
 *********************************************************
 Copyright @ 2015 EMC Corporation All Rights Reserved

--- a/infrasim/init.py
+++ b/infrasim/init.py
@@ -38,10 +38,6 @@ def create_infrasim_directories():
         shutil.rmtree(config.infrasim_logdir)
     os.mkdir(config.infrasim_logdir)
 
-    if not os.path.exists("/usr/local/libexec"):
-        os.mkdir("/usr/local/libexec")
-
-
 def init_infrasim_conf():
 
     # Prepare default network
@@ -74,7 +70,14 @@ def config_library_link():
 
 
 def update_bridge_cfg():
-    run_command('echo "allow br0" > /etc/qemu/bridge.conf')
+    qemu_sys_prefix = os.path.dirname(get_qemu()).replace('bin', '')
+    bridge_conf_loc = os.path.join(qemu_sys_prefix, "etc/qemu")
+    if not os.path.exists(bridge_conf_loc):
+        os.mkdir(bridge_conf_loc)
+
+    bridge_conf = os.path.join(qemu_sys_prefix, bridge_conf_loc, "bridge.conf")
+    with open(bridge_conf, "w") as f:
+        f.write("allow all")
 
 
 def infrasim_init():

--- a/infrasim/ipmi.py
+++ b/infrasim/ipmi.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 '''
 *********************************************************
 Copyright @ 2015 EMC Corporation All Rights Reserved

--- a/infrasim/ipmicons/__init__.py
+++ b/infrasim/ipmicons/__init__.py
@@ -1,2 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-

--- a/infrasim/main.py
+++ b/infrasim/main.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import os
 import sys
 from yaml_loader import YAMLLoader

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -688,9 +688,15 @@ class CNetwork(CElement):
             if self.__bridge_name is None:
                 self.__bridge_name = "br0"
 
+            qemu_sys_prefix = os.path.dirname(
+                Utility.run_command("which qemu-system-x86_64")
+            ).replace("bin", "")
+            bridge_helper = os.path.join(qemu_sys_prefix,
+                                         "libexec",
+                                         "qemu-bridge-helper")
             netdev_option = ",".join(['bridge', 'id=netdev{}'.format(self.__index),
                                       'br={}'.format(self.__bridge_name),
-                                      'helper=/usr/local/libexec/qemu-bridge-helper'])
+                                      'helper={}'.format(bridge_helper)])
             nic_option = ",".join(["{}".format(self.__nic_name),
                                    "netdev=netdev{}".format(self.__index),
                                    "mac={}".format(self.__mac_address)])

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 '''
 *********************************************************
 Copyright @ 2015 EMC Corporation All Rights Reserved

--- a/infrasim/package_install.py
+++ b/infrasim/package_install.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """
 *********************************************************
 Copyright @ 2015 EMC Corporation All Rights Reserved

--- a/infrasim/qemu.py
+++ b/infrasim/qemu.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 '''
 *********************************************************
 Copyright @ 2015 EMC Corporation All Rights Reserved

--- a/infrasim/socat.py
+++ b/infrasim/socat.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 '''
 *********************************************************
 Copyright @ 2015 EMC Corporation All Rights Reserved


### PR DESCRIPTION
    - Remove mkdir for libexec, since qemu installer will create this dir
    - Create bridge config file based on qemu sys exec prefix, and allow all
      bridges, since we may have many bridges on the system
    - get qemu-bridge-helper based on the qemu sys exec prefix, basically,
      if qemu-system-x86_64 was installed at /usr/local/bin, the
      qemu-bridge-helper will be at /usr/local/libexec
