### PR TITLE
Revert "Ignore the EOFError caused by sshim.py when the server is run…

### DIFF
--- a/infrasim/console.py
+++ b/infrasim/console.py
@@ -57,9 +57,8 @@ class IPMI_CONSOLE(threading.Thread):
         while True:
             self.response = ""
             self.prompt()
-            groups = {}
+            groups = self.script.expect(re.compile('(?P<input>.*)')).groupdict()
             try:
-                groups = self.script.expect(re.compile('(?P<input>.*)')).groupdict()
                 cmdline = groups['input'].encode('ascii', 'ignore')
             except:
                 continue


### PR DESCRIPTION
…ning."

This reverts commit e33e7ba3abba9f16c2b911e6a1f0ea55dbaa5c13.

When a script session is closed unexpectedly, it sends EOT (\x04, end of transmission), and script.expect() raise EOFError.
Previously, ipmi-console server shall `continue` and capture nothing in buffer and keep `conitnue`.
Now, it will halt the script session and wait for next connection.