### PR TITLE
[BUGFIX] fix socat exits unexpectedly

### DIFF
--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1315,14 +1315,19 @@ class CCompute(Task, CElement):
         if self.__cdrom_file:
             self.add_option("-cdrom {}".format(self.__cdrom_file))
 
-#        self.add_option("-chardev socket,id=mon,host=127.0.0.1,"
-#                        "port=2345,server,nowait ")
-#
-#        self.add_option("-mon chardev=mon,id=monitor")
-
         if self.__port_serial:
-            self.add_option("-serial mon:udp:127.0.0.1:{},nowait".
-                            format(self.__port_serial))
+            chardev = CCharDev({
+                "backend": "udp",
+                "host": "127.0.0.1",
+                "wait": "off",
+                "port": self.__port_serial
+            })
+            chardev.set_id("serial0")
+            chardev.init()
+            chardev.handle_parms()
+
+            self.add_option(chardev.get_option())
+            self.add_option("-device isa-serial,chardev={}".format(chardev.get_id()))
 
         self.add_option("-uuid {}".format(str(uuid.uuid4())))
 
@@ -1641,7 +1646,7 @@ class CSocat(Task):
 
     def get_commandline(self):
         socat_str = "{0} pty,link={1},waitslave " \
-                    "udp-listen:{2},reuseaddr".\
+            "udp-listen:{2},reuseaddr,fork".\
             format(self.__bin, self.__sol_device, self.__port_serial)
 
         return socat_str

--- a/test/functional/test_configuration_change.py
+++ b/test/functional/test_configuration_change.py
@@ -296,11 +296,12 @@ class test_connection(unittest.TestCase):
 
         str_result = run_command(PS_QEMU, True,
                                  subprocess.PIPE, subprocess.PIPE)[1]
-        assert "-serial mon:udp:127.0.0.1:9103,nowait" in str_result
+        assert "-chardev udp,host=127.0.0.1,port=9103,id=serial0,reconnect=10" in str_result
+        assert "-device isa-serial,chardev=serial0" in str_result
 
         str_result = run_command(PS_SOCAT, True,
                                  subprocess.PIPE, subprocess.PIPE)[1]
-        assert "udp-listen:9103,reuseaddr" in str_result
+        assert "udp-listen:9103,reuseaddr,fork" in str_result
 
     def test_set_node_type(self):
         self.conf["type"] = "dell_c6320"


### PR DESCRIPTION
Add 'fork' for socat, since if connecting socat multiple times, the socat will fail