### PR TITLE
feature/bmc_listen_on_dedicate_interface

### DIFF
--- a/infrasim/helper.py
+++ b/infrasim/helper.py
@@ -4,9 +4,29 @@ Copyright @ 2015 EMC Corporation All Rights Reserved
 *********************************************************
 '''
 import os
+import netifaces
 
 
 def check_kvm_existence():
     if os.path.exists("/dev/kvm"):
         return True
     return False
+
+
+def get_interface_ip(interface):
+    """
+    Get IP address given a interface name
+    :param interface: interface name
+    :return: empty string if no such interface, else IP address
+    """
+    try:
+        addr = netifaces.ifaddresses(interface)
+    except ValueError:
+        return ""
+
+    try:
+        ip = addr[netifaces.AF_INET][0]["addr"]
+    except KeyError:
+        return ""
+
+    return ip

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1359,6 +1359,7 @@ class CBMC(Task):
         self.__bin = "ipmi_sim"
         self.__port_iol = 623
         self.__historyfru = 10
+        self.__ipmi_listen_range = "::"
 
         # Node wise attributes
         self.__vendor_type = None
@@ -1428,8 +1429,15 @@ class CBMC(Task):
             raise ArgsNotCorrect("startcmd script {} doesn\'t exist".
                                  format(self.__chassiscontrol_script))
 
-        # check ports are in use
+        # check ports are not in use
+
         # check lan interface exists
+        if self.__lan_interface not in netifaces.interfaces():
+            raise ArgsNotCorrect("Specified BMC interface {} doesn\'t exist".
+                                 format(self.__lan_interface))
+        if not self.__ipmi_listen_range:
+            raise ArgsNotCorrect("No IP is found on interface {}, BMC can\'t listen".
+                                 format(self.__lan_interface))
 
         # check attribute
         if self.__poweroff_wait < 0:
@@ -1496,6 +1504,7 @@ class CBMC(Task):
                                    chassis_control_script=self.__chassiscontrol_script,
                                    lan_control_script=self.__lancontrol_script,
                                    lan_interface=self.__lan_interface,
+                                   ipmi_listen_range=self.__ipmi_listen_range,
                                    username=self.__username,
                                    password=self.__password,
                                    port_qemu_ipmi=self.__port_qemu_ipmi,
@@ -1519,6 +1528,7 @@ class CBMC(Task):
 
         if 'interface' in self.__bmc:
             self.__lan_interface = self.__bmc['interface']
+            self.__ipmi_listen_range = helper.get_interface_ip(self.__lan_interface)
         else:
             nics_list = netifaces.interfaces()
             self.__lan_interface = filter(lambda x: 'e' in x, nics_list)[0]

--- a/template/vbmc.conf
+++ b/template/vbmc.conf
@@ -16,7 +16,7 @@ set_working_mc 0x20
     # Define an IP address and port to listen on.  You can define more
     # than one address/port to listen on multiple addresses.  The ::
     # listens on all addresses.
-    addr :: {{port_iol}}
+    addr {{ipmi_listen_range}} {{port_iol}}
 
     # Maximum privilege limit on the channel.
     priv_limit admin

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -334,6 +334,42 @@ class bmc_configuration(unittest.TestCase):
                     return
             assert False
 
+    def test_set_ipmi_listen_range(self):
+        bmc_info = {
+            "interface": "lo"
+        }
+
+        bmc = model.CBMC(bmc_info)
+        bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
+        bmc.init()
+        bmc.write_bmc_config()
+        bmc.precheck()
+
+        with open(bmc.get_config_file(), 'r') as fp:
+            for line in fp.readlines():
+                if "addr 127.0.0.1 623" in line:
+                    assert True
+                    return
+            assert False
+
+    def test_set_fake_bmc_lan_interface(self):
+        bmc_info = {
+            "interface": "fake_lan"
+        }
+
+        bmc = model.CBMC(bmc_info)
+        bmc.set_type("quanta_d51")
+        bmc.set_workspace(self.__class__.WORKSPACE)
+        bmc.init()
+        bmc.write_bmc_config()
+        try:
+            bmc.precheck()
+        except ArgsNotCorrect, e:
+            assert "Specified BMC interface fake_lan doesn\'t exist" in str(e)
+        else:
+            assert False
+
     def test_set_startnow_true(self):
         bmc_info = {
             "startnow": True


### PR DESCRIPTION
Added attribute `__ipmi_listen_range`

- `__ipmi_listen_range` will be rendered to `vbmc.conf` template
- if `interface` is given in `infrasim.yml`, this `__ipmi_listen_range` will be set to the interface's IP
- if `interface` is not given, this `__ipmi_listen_range` will be set to `::`, which means vbmc listen on all network

Added CBMC.precheck() rule

- if `__lan_interface` is not a valid interface in system, raise exception
- if `__ipmi_listen_range` is empty, raise exception

Added unit test

    test_set_ipmi_listen_range()
    test_set_fake_bmc_lan_interface()

Added functional test

    test_set_bmc_interface()
	Given vBMC "interface", test vBMC only listen on that interface, and won't response to packets to other interfaces

Added `helper.get_interface_ip()` to get IP address given a interface name