### PR TITLE
A easy to extend REPL and RACADM console with the REPL

### DIFF
--- a/bin/racadmsim
+++ b/bin/racadmsim
@@ -1,0 +1,10 @@
+#!/usr/bin/python
+import sys
+from infrasim import racadmsim
+
+if __name__ == '__main__':
+    racadmsim.start(instance=sys.argv[1],
+                    ipaddr=sys.argv[2],
+                    port=sys.argv[3],
+                    username=sys.argv[4],
+                    password=sys.argv[5])

--- a/etc/infrasim.full.yml.example
+++ b/etc/infrasim.full.yml.example
@@ -153,6 +153,15 @@ bmc:
     emu_file: chassis/node1/quanta_d51.emu
     ipmi_over_lan_port: 623
 
+# racadm is a segment of attributes defined only for dell server
+racadm:
+    # Network to start racadm service
+    interface: br0
+    port: 10022
+    # Credential to access
+    username: admin
+    password: admin
+
 # SSH to this port to visit ipmi-console
 ipmi_console_ssh: 9300
 

--- a/infrasim/init.py
+++ b/infrasim/init.py
@@ -32,8 +32,6 @@ def create_infrasim_directories():
     os.mkdir(config.infrasim_logdir)
 
 
-
-
 def init_infrasim_conf(node_type):
 
     # Prepare default network

--- a/infrasim/racadm.py
+++ b/infrasim/racadm.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+'''
+*********************************************************
+Copyright @ 2015 EMC Corporation All Rights Reserved
+*********************************************************
+'''
+
+import threading
+import re
+from . import sshim
+from .repl import REPL, register
+
+
+class iDRACConsole(threading.Thread):
+    PROMPT = "/admin1-> "
+
+    def __init__(self, script):
+        threading.Thread.__init__(self)
+        self.history = []
+        self.script = script
+        self.response = ''
+        self.start()
+
+    def welcome(self):
+        self.script.writeline("Connecting to {ip}:{port}...")
+        self.script.writeline("Connection established.")
+        self.script.writeline("To escape to local shell, press \'Ctrl+Alt+]\'.")
+        self.script.writeline("")
+
+    def repl_input(self, msg):
+        self.script.write(msg)
+        groups = self.script.expect(re.compile('(?P<cmd>.*)')).groupdict()
+        return groups["cmd"]
+
+    def repl_output(self, msg):
+        for line in msg.splitlines():
+            self.script.writeline(line)
+
+    def run(self):
+        self.welcome()
+        while True:
+            self.script.write(self.PROMPT)
+            groups = self.script.expect(re.compile('(?P<cmd>.*)')).groupdict()
+
+            if groups["cmd"] == "racadm":
+                racadm = RacadmConsole()
+                racadm.set_input(self.repl_input)
+                racadm.set_output(self.repl_output)
+                racadm.run()
+            elif "exit" in groups["cmd"].lower() or "quit" in groups["cmd"].lower():
+                self.script.writeline("Good bye from {}".format(self.__class__.__name__))
+                return
+            else:
+                pass
+
+
+class RacadmConsole(REPL):
+
+    def __init__(self):
+        super(RacadmConsole, self).__init__()
+        self.prompt = "racadm>>"
+
+    @register
+    def hwinventory(self, ctx, args):
+        self.output("hwinventory is not implemented yet")
+        return None
+
+
+if __name__ == "__main__":
+    server = sshim.Server(iDRACConsole, port=10022)
+    server.run()

--- a/infrasim/racadm.py
+++ b/infrasim/racadm.py
@@ -10,6 +10,7 @@ Copyright @ 2015 EMC Corporation All Rights Reserved
 import threading
 import re
 import paramiko
+from os import linesep
 from . import sshim
 from .repl import REPL, register, parse
 
@@ -24,62 +25,6 @@ def auth(username, password):
         return paramiko.AUTH_FAILED
 
 
-class iDRACConsole(threading.Thread):
-    PROMPT = "/admin1-> "
-
-    def __init__(self, script):
-        threading.Thread.__init__(self)
-        self.history = []
-        self.script = script
-        self.response = ''
-        self.start()
-        self.server = None
-
-    def welcome(self):
-        self.script.writeline("Connecting to {ip}:{port}...")
-        self.script.writeline("Connection established.")
-        self.script.writeline("To escape to local shell, press \'Ctrl+Alt+]\'.")
-        self.script.writeline("")
-
-    def repl_input(self, msg):
-        self.script.write(msg)
-        groups = self.script.expect(re.compile('(?P<cmd>.*)')).groupdict()
-        return groups["cmd"]
-
-    def repl_output(self, msg):
-        for line in msg.splitlines():
-            self.script.writeline(line)
-
-    def run(self):
-        self.welcome()
-        while True:
-            self.script.write(self.PROMPT)
-            groups = self.script.expect(re.compile('(?P<cmd>.*)')).groupdict()
-            cmds = groups["cmd"].split()
-
-            if len(cmds) == 0:
-                pass
-            elif cmds[0] == "racadm" and len(cmds) == 1:
-                racadm = RacadmConsole()
-                racadm.set_input(self.repl_input)
-                racadm.set_output(self.repl_output)
-                racadm.run()
-            elif cmds[0] == "racadm":
-                racadm = RacadmConsole()
-                racadm.set_output(self.repl_output)
-                racadm_cmd = parse(" ".join(cmds[1:]))
-                racadm.output(racadm.do(racadm_cmd))
-            elif cmds[0].lower() in ["exit", "quit"]:
-                self.script.writeline("Good bye from {}".format(self.__class__.__name__))
-                return
-            else:
-                self.script.writeline("Support commands:")
-                self.script.writeline("\thelp")
-                self.script.writeline("\tracadm")
-                self.script.writeline("\texit")
-                self.script.writeline("\tquit")
-
-
 class RacadmConsole(REPL):
 
     def __init__(self):
@@ -91,6 +36,36 @@ class RacadmConsole(REPL):
         return "hwinventory is not implemented yet"
 
 
+class iDRACConsole(REPL):
+
+    def __init__(self):
+        super(iDRACConsole, self).__init__()
+        self.prompt = "/admin1-> "
+
+    def welcome(self):
+        lines = ["Connecting to {ip}:{port}...",
+                 "Connection established.",
+                 "To escape to local shell, press \'Ctrl+Alt+]\'.",
+                 "", ""]
+        self.output(linesep.join(lines))
+
+    @register
+    def racadm(self, ctx, args):
+        """
+        Enter racadm console or call racadm sub command
+        """
+        if len(args) == 1:
+            racadm = RacadmConsole()
+            racadm.set_input(self.input)
+            racadm.set_output(self.output)
+            racadm.run()
+        else:
+            racadm = RacadmConsole()
+            racadm.set_output(self.output)
+            racadm_cmd = parse(" ".join(args[1:]))
+            racadm.output(racadm.do(racadm_cmd).strip(linesep))
+
+
 class iDRACHandler(sshim.Handler):
 
     def check_auth_none(self, username):
@@ -99,7 +74,52 @@ class iDRACHandler(sshim.Handler):
     def check_auth_password(self, username, password):
         return auth(username, password)
 
+    def check_channel_exec_request(self, channel, command):
+        cmds = command.split()
+
+        with channel:
+            # If commands is racadm, go to racadm console
+            if cmds == ["racadm"]:
+                channel.send("SSH to iDRAC {}:{} then go to racadm console.{}".
+                             format(self.address, self.server.port, linesep))
+            # else, execute command and response
+            else:
+                idrac = iDRACConsole()
+                idrac.set_output(channel.send)
+                idrac.output(idrac.do(cmds))
+
+        return True
+
+
+class iDRACServer(threading.Thread):
+    PROMPT = "/admin1-> "
+
+    def __init__(self, script):
+        threading.Thread.__init__(self)
+        self.history = []
+        self.script = script
+        self.response = ''
+        self.start()
+        self.server = None
+
+    def repl_input(self, msg):
+        self.script.write(msg)
+        groups = self.script.expect(re.compile('(?P<cmd>.*)')).groupdict()
+        return groups["cmd"]
+
+    def repl_output(self, msg):
+        for line in msg.splitlines():
+            self.script.writeline(line)
+
+    def run(self):
+        self.script.write("Exception here")
+        raise Exception("Here")
+        idrac = iDRACConsole()
+        idrac.set_input(self.repl_input)
+        idrac.set_output(self.repl_output)
+        idrac.run()
+
 
 if __name__ == "__main__":
-    server = sshim.Server(iDRACConsole, port=10022, handler=iDRACHandler)
+    server = sshim.Server(iDRACServer, port=10022, handler=iDRACHandler)
     server.run()

--- a/infrasim/repl.py
+++ b/infrasim/repl.py
@@ -12,6 +12,7 @@ Copyright @ 2015 EMC Corporation All Rights Reserved
 
 from __future__ import print_function
 from functools import wraps
+from os import linesep
 import inspect
 import traceback
 import sys
@@ -183,6 +184,8 @@ class REPL(object):
         else:
             fn_list = self.commands
 
+        lines = []
+
         for fn in sorted(fn_list):
             func = self.commands[fn]
             try:
@@ -191,7 +194,9 @@ class REPL(object):
                 simple_doc = ""
             except AttributeError:
                 simple_doc = ""
-            self.output("\t{:<12}{}".format(fn, simple_doc))
+            lines.append("\t{:<12}{}".format(fn, simple_doc))
+
+        return linesep.join(lines)
 
 if __name__ == "__main__":
     repl = REPL()

--- a/infrasim/repl.py
+++ b/infrasim/repl.py
@@ -86,13 +86,18 @@ class REPL(object):
 
         func = self.commands[cmd[0]]
         try:
-            return func(self, self.context, cmd)
+            rsp = func(self, self.context, cmd)
+            if rsp is None:
+                return linesep
+            else:
+                return str(rsp)+linesep
         except QuitREPL:
             raise
         except Exception:
-            return traceback.format_exc()
+            return traceback.format_exc()+linesep
 
     def run(self):
+        self.welcome()
         while True:
             # READ
             inp = self.input(self.prompt)
@@ -111,7 +116,8 @@ class REPL(object):
                 self.output(out)
 
     def welcome(self):
-        self.output("Welcome to {}".format(self.__class__.__name__))
+        self.output("Welcome to {}{}".
+                    format(self.__class__.__name__, linesep))
 
     def set_prompt(self, prompt="> "):
         self.prompt = prompt
@@ -137,8 +143,7 @@ class REPL(object):
         """
         Print a variable's value in context
         """
-        self.output(ctx[args[1]])
-        return None
+        return ctx[args[1]]
 
     @register
     def define(self, ctx, args):
@@ -162,7 +167,8 @@ class REPL(object):
         """
         Exit this console
         """
-        self.output("Exit {} console, good bye!".format(self.__class__.__name__))
+        self.output("Exit {} console, good bye!{}".
+                    format(self.__class__.__name__, linesep))
         raise QuitREPL()
 
     @register
@@ -170,7 +176,8 @@ class REPL(object):
         """
         Quit this console
         """
-        self.output("Quit {} console, good bye!".format(self.__class__.__name__))
+        self.output("Quit {} console, good bye!{}".
+                    format(self.__class__.__name__, linesep))
         raise QuitREPL()
 
     @register

--- a/infrasim/repl.py
+++ b/infrasim/repl.py
@@ -1,0 +1,198 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+'''
+*********************************************************
+Copyright @ 2015 EMC Corporation All Rights Reserved
+*********************************************************
+'''
+
+# Refer to Lie Ryan's answer at stackoverflow
+# question: "Design python like interactive shell"
+
+from __future__ import print_function
+from functools import wraps
+import inspect
+import traceback
+import sys
+
+
+class register(object):
+    """
+    Do nothing, but wrap fn as a callable instance of type "register"
+    """
+    def __init__(self, fn):
+        self.fn = fn
+
+    def __call__(self):
+        @wraps(self.fn)
+        def wrapper(*args, **kwargs):
+            return self.fn(*args, **kwargs)
+        return wrapper
+
+
+def registered(func):
+    if isinstance(func, register):
+        return True
+    else:
+        return False
+
+
+def parse(s):
+    """
+    Given a command string `s` produce an AST
+    """
+    # the simplest parser is just splitting the input string,
+    # but you can also produce use a more complicated grammer
+    # to produce a more complicated syntax tree
+    return s.split()
+
+
+class QuitREPL(Exception):
+    pass
+
+
+class REPL(object):
+
+    def __init__(self):
+        self.context = {}
+        self.commands = {}
+        self.prompt = '> '
+        self.input = raw_input
+        self.output = print
+
+        # If any method is wrapped as "register", add it into
+        # command map
+        for m_def in inspect.getmembers(self, predicate=registered):
+            m_name = m_def[0]
+            m_func = m_def[1]
+            self.commands[m_name] = m_func()
+
+    def do(self, cmd):
+        """
+        Evaluate the AST, producing an output and/or side effect
+        """
+        # here, we simply use the first item in the list to choose which function to call
+        # in more complicated ASTs, the type of the root node can be used to pick actions
+
+        # Handle ENTER with no input
+        if not cmd:
+            return None
+
+        if cmd[0] not in self.commands:
+            self.output('Unknown command, run "help" for detail')
+            return None
+
+        func = self.commands[cmd[0]]
+        try:
+            return func(self, self.context, cmd)
+        except QuitREPL:
+            raise
+        except Exception:
+            return traceback.format_exc()
+
+    def run(self):
+        while True:
+            # READ
+            inp = self.input(self.prompt)
+
+            # EVAL
+            cmd = parse(inp)
+            try:
+                out = self.do(cmd)
+            except EOFError:
+                return
+            except QuitREPL:
+                return
+
+            # PRINT
+            if out is not None:
+                self.output(out)
+
+    def welcome(self):
+        self.output("Welcome to {}".format(self.__class__.__name__))
+
+    def set_prompt(self, prompt="> "):
+        self.prompt = prompt
+
+    def set_input(self, input=sys.stdin):
+        self.input = input
+
+    def set_output(self, output=sys.stdout):
+        self.output = output
+
+    @register
+    def assign(self, ctx, args):
+        """
+        Assign values
+            assign [a] [b]
+        Create a variable a in context and assign it with value b
+        """
+        ctx[args[1]] = args[2]
+        return '%s = %s' % (args[1], args[2])
+
+    @register
+    def printvar(self, ctx, args):
+        """
+        Print a variable's value in context
+        """
+        self.output(ctx[args[1]])
+        return None
+
+    @register
+    def define(self, ctx, args):
+        """
+        Define a quick function
+        """
+        body = ' '.join(args[2:])
+        ctx[args[1]] = compile(body, '', 'exec')
+        return 'def %s(): %s' % (args[1], body)
+
+    @register
+    def call(self, ctx, args):
+        """
+        Call the function you define
+        """
+        exec ctx[args[1]] in ctx
+        return None
+
+    @register
+    def exit(self, ctx, args):
+        """
+        Exit this console
+        """
+        self.output("Exit {} console, good bye!".format(self.__class__.__name__))
+        raise QuitREPL()
+
+    @register
+    def quit(self, ctx, args):
+        """
+        Quit this console
+        """
+        self.output("Quit {} console, good bye!".format(self.__class__.__name__))
+        raise QuitREPL()
+
+    @register
+    def help(self, ctx, args):
+        """
+        Show command helps
+        """
+
+        if len(args) >= 2:
+            fn_list = args[1:]
+        else:
+            fn_list = self.commands
+
+        for fn in sorted(fn_list):
+            func = self.commands[fn]
+            try:
+                simple_doc = func.__doc__.splitlines()[1]
+            except IndexError:
+                simple_doc = ""
+            except AttributeError:
+                simple_doc = ""
+            self.output("\t{:<12}{}".format(fn, simple_doc))
+
+if __name__ == "__main__":
+    repl = REPL()
+    repl.run()

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ packages =
 scripts =
     bin/infrasim
     bin/ipmi-console
+    bin/racadmsim
 data_files =
     infrasim/data = data/*
     infrasim/template = template/*


### PR DESCRIPTION
Added module infrasim.repl
Implemented iDRAC SSH simulation, with command `racadm` to go
to racadm console

Check how `RacadmConsole` inherits `REPL` and how it be used in another ssh service:

    racadm = RacadmConsole()
    racadm.set_input(self.repl_input)
    racadm.set_output(self.repl_output)
    racadm.run()

How to try this implementation:
1. Go to infrasim code folder
2. Run server with:

    sudo python -m infrasim.racadm

3. Start another SSH session with putty for example, to connect to port `10022`