### PR TITLE
Simulate racadm console behavior

### DIFF
--- a/bin/racadmsim
+++ b/bin/racadmsim
@@ -7,4 +7,5 @@ if __name__ == '__main__':
                     ipaddr=sys.argv[2],
                     port=sys.argv[3],
                     username=sys.argv[4],
-                    password=sys.argv[5])
+                    password=sys.argv[5],
+                    data_src=sys.argv[6])

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1726,6 +1726,7 @@ class CRacadm(Task):
         self.__password = ""
         self.__interface = None
         self.__ip = ""
+        self.__data_src = ""
 
     def precheck(self):
         if not self.__ip:
@@ -1746,18 +1747,20 @@ class CRacadm(Task):
         self.__port_idrac = self.__racadm_info.get("port", 10022)
         self.__username = self.__racadm_info.get("username", "admin")
         self.__password = self.__racadm_info.get("password", "admin")
+        self.__data_src = self.__racadm_info.get("data", "auto")
 
     def set_node_name(self, name):
         self.__node_name = name
 
     def get_commandline(self):
-        racadmsim_str = "{} {} {} {} {} {}".\
+        racadmsim_str = "{} {} {} {} {} {} {}".\
             format(self.__bin,
                    self.__node_name,
                    self.__ip,
                    self.__port_idrac,
                    self.__username,
-                   self.__password)
+                   self.__password,
+                   self.__data_src)
         return racadmsim_str
 
 

--- a/infrasim/racadmsim.py
+++ b/infrasim/racadmsim.py
@@ -10,11 +10,13 @@ Copyright @ 2015 EMC Corporation All Rights Reserved
 import threading
 import re
 import paramiko
+import os
 from os import linesep
 from . import sshim, logger
 from .repl import REPL, register, parse, QuitREPL
 
 auth_map = {}
+racadm_data = None
 
 
 def auth(username, password):
@@ -23,6 +25,19 @@ def auth(username, password):
         return paramiko.AUTH_SUCCESSFUL
     else:
         return paramiko.AUTH_FAILED
+
+
+def fake_data(name):
+    global racadm_data
+    if not racadm_data:
+        return None
+    data_path = os.path.join(racadm_data, name)
+    if os.path.exists(data_path):
+        with open(data_path) as fp:
+            rsp = linesep.join(fp.read().splitlines())
+        return rsp
+    else:
+        return None
 
 
 class RacadmConsole(REPL):
@@ -44,8 +59,76 @@ class RacadmConsole(REPL):
                 return cmd
 
     @register
+    def getled(self, ctx, args):
+        """
+        [RACADM] get led status
+        """
+        return fake_data("getled")
+
+    @register
+    def getsysinfo(self, ctx, args):
+        """
+        [RACADM] get system info
+        """
+        return fake_data("getsysinfo")
+
+    @register
+    def storage(self, ctx, args):
+        """
+        [RACADM] get storage information
+        """
+        if args == ["storage", "get", "pdisks", "-o"]:
+            return fake_data("storage_get_pdisks_o")
+        else:
+            return None
+
+    @register
+    def get(self, ctx, args):
+        """
+        [RACADM] get device information
+        """
+        if args == ["get", "BIOS"]:
+            return fake_data("get_bios")
+        elif args == ["get", "BIOS.MemSettings"]:
+            return fake_data("get_bios_mem_setting")
+        elif args == ["get", "IDRAC"]:
+            return fake_data("get_idrac")
+        elif args == ["get", "LifeCycleController"]:
+            return fake_data("get_life_cycle_controller")
+        elif args == ["get", "LifeCycleController.LCAttributes"]:
+            return fake_data("get_life_cycle_controller_lc_attributes")
+        else:
+            return None
+
+    @register
     def hwinventory(self, ctx, args):
-        return "hwinventory is not implemented yet"
+        """
+        [RACADM] hwinventory
+        """
+        if args == ["hwinventory"]:
+            return fake_data("hwinventory")
+        elif args == ["hwinventory", "nic"]:
+            return fake_data("hwinventory_nic")
+        elif args == ["hwinventory", "nic.Integrated.1-1-1"]:
+            return fake_data("hwinventory_nic_integrated_1-1-1")
+        elif args == ["hwinventory", "nic.Integrated.1-2-1"]:
+            return fake_data("hwinventory_nic_integrated_1-2-1")
+        elif args == ["hwinventory", "nic.Integrated.1-3-1"]:
+            return fake_data("hwinventory_nic_integrated_1-3-1")
+        elif args == ["hwinventory", "nic.Integrated.1-4-1"]:
+            return fake_data("hwinventory_nic_integrated_1-4-1")
+        else:
+            return None
+
+    @register
+    def setled(self, ctx, args):
+        """
+        [RACADM] set led status
+        """
+        if args == ["setled", "-l", "0"]:
+            return fake_data("setled_l_0")
+        else:
+            return None
 
     def run(self):
         self.welcome()
@@ -160,10 +243,14 @@ def start(instance="default",
           ipaddr="",
           port=10022,
           username="admin",
-          password="admin"):
+          password="admin",
+          data_src="auto"):
     # Init environment
     global auth_map
+    global racadm_data
     auth_map[username] = password
+    if os.path.exists(data_src):
+        racadm_data = data_src
 
     server = sshim.Server(iDRACServer,
                           address=ipaddr,


### PR DESCRIPTION
Two behaviors to simulate in this patch:
- in racadm REPL, it echo command then print result
- in racadm REPL, it ignores a redundant prefix racadm, so when
you type `racadm getled`, you are actually running `getled`