### PR TITLE
Catch namespace doesn't exist exception

### DIFF
--- a/infrasim/helper.py
+++ b/infrasim/helper.py
@@ -10,7 +10,7 @@ from ctypes import cdll
 import fcntl
 import struct
 import array
-from infrasim import run_command
+from infrasim import run_command, InfraSimError
 from infrasim import logger
 
 libc = cdll.LoadLibrary('libc.so.6')
@@ -41,6 +41,7 @@ def run_in_namespace(func):
         if namespace:
             with Namespace(nsname=namespace):
                 ret = func(*args, **kwargs)
+
         else:
             ret = func(*args, **kwargs)
         return ret
@@ -126,8 +127,8 @@ class Namespace(object):
                                       nsname=nsname,
                                       nspid=nspid)
 
-        if not self.targetpath:
-            raise ValueError('invalid namespace')
+        if not os.path.exists(self.targetpath):
+            raise InfraSimError('invalid namespace {}'.format(nsname))
 
     def __enter__(self):
         self.myns = open(self.mypath)

--- a/infrasim/ipmi.py
+++ b/infrasim/ipmi.py
@@ -8,7 +8,7 @@ Copyright @ 2015 EMC Corporation All Rights Reserved
 import os
 import yaml
 import config
-from . import run_command, logger, ArgsNotCorrect, CommandNotFound, CommandRunFailed
+from . import run_command, logger, ArgsNotCorrect, CommandNotFound, CommandRunFailed, InfraSimError
 from model import CBMC, CNode
 
 
@@ -58,6 +58,9 @@ def start_ipmi(conf_file=config.infrasim_default_config):
         logger.error(e.value)
         raise e
     except ArgsNotCorrect as e:
+        logger.error(e.value)
+        raise e
+    except InfraSimError as e:
         logger.error(e.value)
         raise e
 

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1981,8 +1981,11 @@ class CNode(object):
             for task in self.__tasks_list:
                 task.netns = self.__netns
 
-        for task in self.__tasks_list:
-            task.init()
+        try:
+            for task in self.__tasks_list:
+                task.init()
+        except Exception, e:
+            raise e
 
     # Run tasks list as the priority
     def start(self):

--- a/infrasim/qemu.py
+++ b/infrasim/qemu.py
@@ -9,7 +9,7 @@ import os
 import yaml
 import time
 import config
-from . import run_command, logger, CommandNotFound, CommandRunFailed, ArgsNotCorrect
+from . import run_command, logger, CommandNotFound, CommandRunFailed, ArgsNotCorrect, InfraSimError
 from model import CCompute
 
 
@@ -96,6 +96,9 @@ def start_qemu(conf_file=config.infrasim_default_config):
         logger.error(e.value)
         raise e
     except ArgsNotCorrect as e:
+        logger.error(e.value)
+        raise e
+    except InfraSimError as e:
         logger.error(e.value)
         raise e
 

--- a/infrasim/socat.py
+++ b/infrasim/socat.py
@@ -10,7 +10,7 @@ import time
 import yaml
 import config
 from infrasim.model import CSocat, CNode
-from . import run_command, logger, CommandNotFound, CommandRunFailed
+from . import run_command, logger, CommandNotFound, CommandRunFailed, InfraSimError
 
 
 def get_socat():
@@ -57,6 +57,9 @@ def start_socat(conf_file=config.infrasim_default_config):
         time.sleep(3)
         logger.info("socat start")
     except CommandRunFailed as e:
+        logger.error(e.value)
+        raise e
+    except InfraSimError as e:
         logger.error(e.value)
         raise e
 


### PR DESCRIPTION
Add check in Namespace __init__ to check if network namespace exists. If not, raise InfraSimError.
Catch namespace error in cli command handler and add it to error log in ipmi, qemu, socat start functions.