### PR TITLE
bugfix/racadm_robust

### DIFF
--- a/infrasim/racadmsim.py
+++ b/infrasim/racadmsim.py
@@ -173,18 +173,32 @@ class iDRACConsole(REPL):
         Enter racadmsim console or call sub commands
         """
         if len(args) == 1:
-            racadm = RacadmConsole()
-            racadm.set_input(self.input)
-            racadm.set_output(self.output)
-            racadm.run()
+            self.output("Not supported yet.")
+            return
+            # racadm = RacadmConsole()
+            # racadm.set_input(self.input)
+            # racadm.set_output(self.output)
+            # racadm.run()
         else:
             racadm = RacadmConsole()
             racadm.set_output(self.output)
             racadm_cmd = parse(" ".join(args[1:]))
-            racadm.output(racadm.do(racadm_cmd).strip(linesep))
+            rsp = racadm.do(racadm_cmd)
+            if rsp:
+                racadm.output(rsp.strip(linesep))
+            else:
+                racadm.output(linesep)
 
 
 class iDRACHandler(sshim.Handler):
+    def __init__(self, server, connection):
+        # paramiko.ServerInterface.start_server() raise exception
+        # and make server instance quite.
+        # Here the exception is captured in case of a service stop
+        try:
+            super(iDRACHandler, self).__init__(server, connection)
+        except Exception:
+            pass
 
     def check_auth_none(self, username):
         return paramiko.AUTH_FAILED
@@ -260,5 +274,8 @@ def start(instance="default",
     server.run()
 
 if __name__ == "__main__":
+    # Try to run this from code root directory, with command:
+    #     python -m infrasim.racadmsim
+    auth_map["admin"] = "admin"
     server = sshim.Server(iDRACServer, port=10022, handler=iDRACHandler)
     server.run()

--- a/infrasim/repl.py
+++ b/infrasim/repl.py
@@ -81,7 +81,7 @@ class REPL(object):
             return None
 
         if cmd[0] not in self.commands:
-            self.output('Unknown command, run "help" for detail')
+            self.output('Unknown command, run "help" for detail'+linesep)
             return None
 
         func = self.commands[cmd[0]]

--- a/test/functional/test_racadm.py
+++ b/test/functional/test_racadm.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python
+'''
+*********************************************************
+Copyright @ 2015 EMC Corporation All Rights Reserved
+*********************************************************
+'''
+# -*- coding: utf-8 -*-
+
+
+import unittest
+import subprocess
+import os
+import time
+import paramiko
+from infrasim import model
+from test import fixtures
+
+PS_RACADM = "ps ax | grep racadmsim"
+
+TMP_CONF_FILE = "/tmp/test.yml"
+
+
+def run_command(cmd="", shell=True, stdout=None, stderr=None):
+    child = subprocess.Popen(cmd, shell=shell,
+                             stdout=stdout, stderr=stderr)
+    cmd_result = child.communicate()
+    cmd_return_code = child.returncode
+    if cmd_return_code != 0:
+        return -1, cmd_result[1]
+    return 0, cmd_result[0]
+
+
+def read_buffer(channel):
+    while not channel.recv_ready():
+        continue
+    str_output = ''
+    str_read = ''
+    while True:
+        str_read = str(channel.recv(40960))
+        str_output += str_read
+        if str_output.find('/admin1-> \n'):
+            break
+        time.sleep(1)
+    return str_output
+
+
+class test_racadm_robust(unittest.TestCase):
+
+    ssh = paramiko.SSHClient()
+    channel = None
+
+    def setUp(self):
+        fake_config = fixtures.FakeConfig()
+        self.conf = fake_config.get_node_info()
+        self.conf["type"] = "dell_c6320"
+
+    def tearDown(self):
+        if self.channel:
+            self.channel.send('quit\n')
+            self.channel.close()
+        self.ssh.close()
+
+        node = model.CNode(self.conf)
+        node.init()
+        node.stop()
+        node.terminate_workspace()
+        if os.path.exists(TMP_CONF_FILE):
+            os.unlink(TMP_CONF_FILE)
+        self.conf = None
+
+    def test_server_live_after_inline_wrong_password(self):
+
+        str_result = run_command("which sshpass", True,
+                                 subprocess.PIPE, subprocess.PIPE)
+        if str_result[0] != 0:
+            self.skipTest("Need sshpass to test inline ssh command")
+
+        # Start service
+        node = model.CNode(self.conf)
+        node.init()
+        node.precheck()
+        node.start()
+
+        # Use wrong credential
+        cmd_help = "sshpass -p 'fake' " \
+                   "ssh admin@127.0.0.1 " \
+                   "-p 10022 " \
+                   "-o StrictHostKeyChecking=no " \
+                   "help"
+        child = subprocess.Popen(cmd_help, shell=True,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        cmd_result = child.communicate()
+        assert "Permission denied" in cmd_result[1]
+
+        # Verify server is alive
+        self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.ssh.connect('127.0.0.1',
+                         username='admin',
+                         password='admin',
+                         port=10022)
+        self.channel = self.ssh.invoke_shell()
+        self.channel.send("racadm help"+chr(13))
+        time.sleep(1)
+        str_output = read_buffer(self.channel)
+        assert "hwinventory" in str_output
+
+    def test_server_live_after_inline_wrong_username(self):
+
+        str_result = run_command("which sshpass", True,
+                                 subprocess.PIPE, subprocess.PIPE)
+        if str_result[0] != 0:
+            self.skipTest("Need sshpass to test inline ssh command")
+
+        # Start service
+        node = model.CNode(self.conf)
+        node.init()
+        node.precheck()
+        node.start()
+
+        # Use wrong credential
+        cmd_help = "sshpass -p 'admin' " \
+                   "ssh fake@127.0.0.1 " \
+                   "-p 10022 " \
+                   "-o StrictHostKeyChecking=no " \
+                   "help"
+        child = subprocess.Popen(cmd_help, shell=True,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        cmd_result = child.communicate()
+        assert "Permission denied" in cmd_result[1]
+
+        # Verify server is alive
+        self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.ssh.connect('127.0.0.1',
+                         username='admin',
+                         password='admin',
+                         port=10022)
+        self.channel = self.ssh.invoke_shell()
+        self.channel.send("racadm help"+chr(13))
+        time.sleep(1)
+        str_output = read_buffer(self.channel)
+        assert "hwinventory" in str_output
+
+    def test_server_live_after_inline_wrong_command(self):
+
+        str_result = run_command("which sshpass", True,
+                                 subprocess.PIPE, subprocess.PIPE)
+        if str_result[0] != 0:
+            self.skipTest("Need sshpass to test inline ssh command")
+
+        # Start service
+        node = model.CNode(self.conf)
+        node.init()
+        node.precheck()
+        node.start()
+
+        # Use wrong credential
+        cmd_help = "sshpass -p 'admin' " \
+                   "ssh admin@127.0.0.1 " \
+                   "-p 10022 " \
+                   "-o StrictHostKeyChecking=no " \
+                   "fake"
+        child = subprocess.Popen(cmd_help, shell=True,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        cmd_result = child.communicate()
+        assert 'Unknown command, run "help" for detail' in cmd_result[0]
+
+        # Verify server is alive
+        self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.ssh.connect('127.0.0.1',
+                         username='admin',
+                         password='admin',
+                         port=10022)
+        self.channel = self.ssh.invoke_shell()
+        self.channel.send("racadm help"+chr(13))
+        time.sleep(1)
+        str_output = read_buffer(self.channel)
+        assert "hwinventory" in str_output
+
+    def test_server_live_after_inline_wrong_racadm_command(self):
+
+        str_result = run_command("which sshpass", True,
+                                 subprocess.PIPE, subprocess.PIPE)
+        if str_result[0] != 0:
+            self.skipTest("Need sshpass to test inline ssh command")
+
+        # Start service
+        node = model.CNode(self.conf)
+        node.init()
+        node.precheck()
+        node.start()
+
+        # Use wrong credential
+        cmd_help = "sshpass -p 'admin' " \
+                   "ssh admin@127.0.0.1 " \
+                   "-p 10022 " \
+                   "-o StrictHostKeyChecking=no " \
+                   "racadm fake"
+        child = subprocess.Popen(cmd_help, shell=True,
+                                 stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        cmd_result = child.communicate()
+        assert 'Unknown command, run "help" for detail' in cmd_result[0]
+
+        # Verify server is alive
+        self.ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        self.ssh.connect('127.0.0.1',
+                         username='admin',
+                         password='admin',
+                         port=10022)
+        self.channel = self.ssh.invoke_shell()
+        self.channel.send("racadm help"+chr(13))
+        time.sleep(1)
+        str_output = read_buffer(self.channel)
+        assert "hwinventory" in str_output


### PR DESCRIPTION
paramiko.ServerInterface sometime raises exception if auth fail.
Capture this exception in case server quit.

Added test to verify server is alive after:
- wrong credential
- wrong commands