### PR TITLE
Remove netifaces from test and enhance testing 

### DIFF
--- a/infrasim/helper.py
+++ b/infrasim/helper.py
@@ -11,7 +11,6 @@ import fcntl
 import struct
 import array
 from infrasim import run_command
-from infrasim import logger
 
 libc = cdll.LoadLibrary('libc.so.6')
 setns = libc.setns
@@ -76,7 +75,6 @@ def get_all_interfaces():
     for i in range(0, returned_bytes, 40):
         intfn = interface_names_str[i:i+16].split('\0', 1)[0]
         intf_list.append(intfn)
-    logger.info(intf_list)
     return intf_list
 
 

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1152,6 +1152,7 @@ class CCompute(Task, CElement):
         self.__sol_enabled = False
         self.__kernel = None
         self.__initrd = None
+        self.__cmdline = None
         self.__mem_path = None
 
     def enable_sol(self, enabled):
@@ -1251,6 +1252,8 @@ class CCompute(Task, CElement):
 
         if 'initrd' in self.__compute:
             self.__initrd = self.__compute['initrd']
+
+        self.__cmdline = self.__compute.get("cmdline")
 
         self.__mem_path = self.__compute.get("mem_path")
 
@@ -1388,6 +1391,9 @@ class CCompute(Task, CElement):
 
         if self.__kernel and self.__initrd:
             self.add_option("-kernel {} -initrd {}".format(self.__kernel, self.__initrd))
+
+        if self.__cmdline:
+            self.add_option("--append \"{}\"".format(self.__cmdline))
 
         for element_obj in self.__element_list:
             element_obj.handle_parms()

--- a/test/functional/test_racadm.py
+++ b/test/functional/test_racadm.py
@@ -53,6 +53,8 @@ class test_racadm_robust(unittest.TestCase):
         fake_config = fixtures.FakeConfig()
         self.conf = fake_config.get_node_info()
         self.conf["type"] = "dell_c6320"
+        self.old_path = os.environ.get("PATH")
+        os.environ["PATH"] = "{}/bin:{}".format(os.environ.get("PYTHONPATH"), self.old_path)
 
     def tearDown(self):
         if self.channel:
@@ -67,6 +69,7 @@ class test_racadm_robust(unittest.TestCase):
         if os.path.exists(TMP_CONF_FILE):
             os.unlink(TMP_CONF_FILE)
         self.conf = None
+        os.environ["PATH"] = self.old_path
 
     def test_server_live_after_inline_wrong_password(self):
 

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -7,7 +7,6 @@ Copyright @ 2015 EMC Corporation All Rights Reserved
 import os
 import unittest
 import yaml
-import netifaces
 from infrasim import ArgsNotCorrect
 from infrasim import model
 from infrasim import socat
@@ -788,7 +787,7 @@ class racadm_configuration(unittest.TestCase):
             assert ":22 is already in use" in str(e)
 
     def test_non_exist_interface(self):
-        fake_interface = "fake"+netifaces.interfaces()[0]
+        fake_interface = "fake0"
 
         racadm_info = {
             "interface": fake_interface


### PR DESCRIPTION
 - Remove useless log in helper
- Remove the netifaces used by test code
- Make the functional testing work without installation
---
 Add qemu parameters "--append"

Add this 'cmdline' in ymal configuration as below:
...
compute:
    ...
    - cmdline: "..."

this will make qemu to generate the command line qemu-system-x86_64 ...
--append "..."

---
Test racadmsim without installation