### PR TITLE
start-ipmi-console-for-default

### DIFF
--- a/infrasim/console.py
+++ b/infrasim/console.py
@@ -21,6 +21,7 @@ from ipmicons import sdr, common
 import daemon
 from infrasim import config
 import signal
+from infrasim import run_command
 
 server = None
 
@@ -93,6 +94,7 @@ def _start_console():
     try:
         logger.info("ipmi-console start")
         server.run()
+
     except KeyboardInterrupt:
         server.stop()
 
@@ -133,26 +135,29 @@ def _free_resource():
         thread.join()
 
 
-def start(instance="node-0"):
+def start(instance="default"):
     """
     Attach ipmi-console to target instance specified by
     its name
     :param instance: infrasim instance name
     """
     daemon.daemonize("{}/{}/.ipmi_console.pid".format(config.infrasim_home, instance))
-
     # initialize logging
-    common.init_logger()
+    common.init_logger(instance)
+
     # initialize environment
     common.init_env(instance)
+
     # parse the sdrs and build all sensors
     sdr.parse_sdrs()
+
     # running thread for each threshold based sensor
     _spawn_sensor_thread()
+
     _start_console()
 
 
-def stop(instance="node-0"):
+def stop(instance="default"):
     """
     Stop ipmi-console of target instance specified by
     its name
@@ -170,11 +175,16 @@ def stop(instance="node-0"):
         pass
 
 
-def console_main(instance="node-0"):
+def console_main(instance="default"):
     if len(sys.argv) < 2:
-        print "ipmi-console [ start | stop ]"
+        print "ipmi-console [ start | stop ] ( node_name )"
         sys.exit(1)
-
+    if len(sys.argv) >= 3:
+        if sys.argv[3] == "-h":
+            print "ipmi-console [ start | stop ] ( node_name )"
+            sys.exit(1)
+        else:
+            instance = sys.argv[3]
     if sys.argv[1] == "start":
         start(instance)
     elif sys.argv[1] == "stop":

--- a/infrasim/ipmicons/common.py
+++ b/infrasim/ipmicons/common.py
@@ -14,12 +14,14 @@ import Queue
 import re
 import env
 import traceback
+from infrasim import config
+
 
 lock = threading.Lock()
 
 # logger
-logger = logging.getLogger("ipmi_sim")
-LOG_FILE = '/var/log/ipmi_sim.log'
+logger = logging.getLogger("ipmi-console")
+
 
 # telnet to vBMC
 tn = telnetlib.Telnet()
@@ -27,14 +29,20 @@ tn = telnetlib.Telnet()
 msg_queue = Queue.Queue()
 
 
-def init_logger():
+def init_logger(instance="default"):
+
     logger.setLevel(logging.ERROR)
 
-    if os.path.isfile(LOG_FILE) is True:
-        os.remove(LOG_FILE)
+    log_folder = os.path.join(config.infrasim_logdir, instance)
+    if not os.path.exists(log_folder):
+        os.mkdir(log_folder)
+    log_path = os.path.join(log_folder, "ipmi-console.log")
+
+    if os.path.isfile(log_path) is True:
+        os.remove(log_path)
 
     # create file handler which logs even debug messages
-    fh = logging.FileHandler(LOG_FILE)
+    fh = logging.FileHandler(log_path)
 
     # create console handler with a higher log level
     # ch = logging.StreamHandler()

--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -130,6 +130,12 @@ class test_ipmi_console(unittest.TestCase):
         if os.path.exists(workspace):
             shutil.rmtree(workspace)
 
+    def test_start(self):
+        ipmi_start_cmd = 'ps ax | grep ipmi-console'
+        returncode, output = run_command(ipmi_start_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        self.assertEqual(returncode, 0)
+        assert 'ipmi-console start' in output
+
     def test_sensor_accessibility(self):
         self.channel.send('sensor info\n')
         time.sleep(1)


### PR DESCRIPTION
1. Can start ipmi-console for default node and **other specified node by its name**.
2. Change ipmi-console log path to node's data space.Eg, for default node:  /var/log/infrasim/default/ipmi-console.log
3. Add a ipmi start test in test_ipmi_console.py:test_ipmi_console 'test_start(self)'