### PR TITLE
develop/ipmi-console robust/cannot start ipmi-console when not bmc

### DIFF
--- a/infrasim/console.py
+++ b/infrasim/console.py
@@ -141,17 +141,20 @@ def start(instance="default"):
     its name
     :param instance: infrasim instance name
     """
-    daemon.daemonize("{}/{}/.ipmi_console.pid".format(config.infrasim_home, instance))
-    # initialize logging
-    common.init_logger(instance)
-    # initialize environment
-    common.init_env(instance)
-    # parse the sdrs and build all sensors
-    sdr.parse_sdrs()
-    # running thread for each threshold based sensor
-    _spawn_sensor_thread()
-    _start_console()
-
+    output = run_command("infrasim node status")
+    if output[0] == 0 and "stop" not in output[1]:
+        daemon.daemonize("{}/{}/.ipmi_console.pid".format(config.infrasim_home, instance))
+        # initialize logging
+        common.init_logger(instance)
+        # initialize environment
+        common.init_env(instance)
+        # parse the sdrs and build all sensors
+        sdr.parse_sdrs()
+        # running thread for each threshold based sensor
+        _spawn_sensor_thread()
+        _start_console()
+    else:
+        print "Warning: have not started BMC. Please start a node first."
 
 def stop(instance="default"):
     """

--- a/infrasim/console.py
+++ b/infrasim/console.py
@@ -176,11 +176,11 @@ def console_main(instance="default"):
         print "ipmi-console [ start | stop ]"
         sys.exit(1)
     if len(sys.argv) >= 3:
-        if sys.argv[3] == "-h":
+        if sys.argv[2] == "-h":
             print "ipmi-console [ start | stop ] [ node_name ]"
             sys.exit(1)
         else:
-            instance = sys.argv[3]
+            instance = sys.argv[2]
     if sys.argv[1] == "start":
         start(instance)
     elif sys.argv[1] == "stop":

--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -92,6 +92,26 @@ class test_ipmi_console_start_stop(unittest.TestCase):
         self.assertEqual(returncode1, 0)
         assert 'ipmi-console start' not in output1
 
+    def test_start_stop_specified_ipmi_console(self):
+        self.node_name = "test_"
+        self.node_workspace = os.path.join(config.infrasim_home, self.node_name)
+        node_config_path = "test.yml"
+        node_info = FakeConfig().get_node_info()
+        with open(node_config_path, "w") as fp:
+            yaml.dump(node_info, fp, default_flow_style=False)
+        os.system("infrasim config add {} {}".format(self.node_name, node_config_path))
+        os.system("infrasim node start {}".format(self.node_name))
+        os.system("ipmi-console start {}".format(self.node_name))
+        ipmi_start_cmd = 'ps ax | grep ipmi-console'
+        returncode, output = run_command(ipmi_start_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        os.system("ipmi-console stop {}".format(self.node_name))
+        ipmi_stop_cmd = 'ps ax | grep ipmi-console'
+        returncode1, output1 = run_command(ipmi_stop_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        self.assertEqual(returncode, 0)
+        self.assertEqual(returncode, 0)
+        assert 'ipmi-console start {}'.format(self.node_name) in output
+        self.assertEqual(returncode1, 0)
+        assert 'ipmi-console start {}'.format(self.node_name) not in output1
 
 class test_ipmi_console(unittest.TestCase):
 

--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -113,6 +113,19 @@ class test_ipmi_console_start_stop(unittest.TestCase):
         self.assertEqual(returncode1, 0)
         assert 'ipmi-console start {}'.format(self.node_name) not in output1
 
+    def test_start_ipmi_console_not_start_bmc(self):
+        self.node_name = "default"
+        self.node_workspace = os.path.join(config.infrasim_home, self.node_name)
+        os.system("infrasim node start")
+        os.system("infrasim node stop")
+        os.system("ipmi-console start")
+        ipmi_start_cmd = 'ps ax | grep ipmi-console'
+        returncode, output = run_command(ipmi_start_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        os.system("ipmi-console stop")
+        self.assertEqual(returncode, 0)
+        assert 'ipmi-console start' not in output
+
+
 class test_ipmi_console(unittest.TestCase):
 
     ssh = paramiko.SSHClient()

--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -22,6 +22,7 @@ import shutil
 import telnetlib
 import socket
 import signal
+from test.fixtures import FakeConfig
 
 
 def run_command(cmd="", shell=True, stdout=None, stderr=None):
@@ -66,35 +67,30 @@ def reset_console(channel, timeout=10):
             raise RuntimeError('ipmi-console reset expires {}s'.
                                format(timeout))
 
-class test_ipmi_start_stop(unittest.TestCase):
-    node_name = "default"
-    node_workspace = os.path.join(config.infrasim_home, node_name)
 
-    def test_start_stop(self):
-        os.system("sudo ipmi-console stop")
-        os.system("sudo infrasim node destroy")
+class test_ipmi_console_start_stop(unittest.TestCase):
+
+    def tearDown(self):
+        os.system("infrasim node destroy {}".format(self.node_name))
         os.system("rm -rf {}".format(self.node_workspace))
         os.system("pkill socat")
         os.system("pkill ipmi")
         os.system("pkill qemu")
-        os.system("sudo infrasim node start")
-        os.system("sudo ipmi-console start")
+
+    def test_start_stop_default_ipmi_console(self):
+        self.node_name = "default"
+        self.node_workspace = os.path.join(config.infrasim_home, self.node_name)
+        os.system("infrasim node start")
+        os.system("ipmi-console start")
         ipmi_start_cmd = 'ps ax | grep ipmi-console'
         returncode, output = run_command(ipmi_start_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        os.system("sudo ipmi-console stop")
+        os.system("ipmi-console stop")
         ipmi_stop_cmd = 'ps ax | grep ipmi-console'
         returncode1, output1 = run_command(ipmi_stop_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        os.system("sudo infrasim node destroy")
-        os.system("rm -rf {}".format(self.node_workspace))
-        os.system("pkill socat")
-        os.system("pkill ipmi")
-        os.system("pkill qemu")
-
         self.assertEqual(returncode, 0)
         assert 'ipmi-console start' in output
         self.assertEqual(returncode1, 0)
         assert 'ipmi-console start' not in output1
-
 
 
 class test_ipmi_console(unittest.TestCase):


### PR DESCRIPTION
1. Add code: cannot start ipmi-console when not started BMC;
2. Add test: add a test to check we cannot start ipmi-console when not started BMC.
(Please merge PR186 first)