### PR TITLE
Remove setup.cfg version writing from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,6 @@
 # limitations under the License.
 
 # THIS FILE IS MANAGED BY THE GLOBAL REQUIREMENTS REPO - DO NOT EDIT
-import re
-import json
-import fileinput
 
 # In python < 2.7.4, a lazy loading of package `pbr` will break
 # setuptools if some other modules registered functions in `atexit`.
@@ -26,39 +23,8 @@ try:
     import multiprocessing  # noqa
 except ImportError:
     pass
-import requests
 import setuptools
 
-
-def load_version(filename):
-    version = None
-    with open(filename) as verfile:
-        for line in verfile:
-            version = re.search('\d+.\d+.\d+', line)
-            if version is not None:
-                version = version.group()
-                break
-    return version
-
-ver = load_version("template/version.yml")
-if ver is not None:
-    for line in fileinput.input("setup.cfg", inplace=True):
-        if line.startswith("version ="):
-            continue
-
-        print line,
-        if line.startswith("summary"):
-            print "version =", ver
-else:
-    r = requests.get("https://api.github.com/repos/InfraSIM/infrasim-compute/releases/latest")
-    if r.ok:
-        data = json.loads(r.content)
-        ver = data['tag_name']
-    for line in fileinput.input("template/version.yml", inplace=True):
-        if line.startswith("version"):
-            print "version: ", ver,
-        else:
-            print line,
 
 setuptools.setup(
     setup_requires=['pbr'],

--- a/template/version.yml
+++ b/template/version.yml
@@ -1,3 +1,3 @@
 ---
 #This file is for infrasim-compute version
-version: 3.0.0 
+version: 3.0.1 


### PR DESCRIPTION
Since we use pbr package to handle the versioning scheme, pbr will do the following steps when we setup or package:
1. Check setup.cfg to see if version is set.
2. Read tags in local git to retrieve the latest version tag.
3. Compare the version number in setup.cfg with the latest tag.
	a. If no version is set in setup.cfg:
		a.a if no version tag is found in "git tag", package version = 0.0.1.dev{total commit number}
		a.b if version tag is found in "git tag":
			a.b.a if version tag is tagged on the latest commit, package version = this number.
			a.b.b if version tag is tagged on an old commit, package version = {version tag number}.dev{latest commit number - tag commit number}.
	b. If version is set in setup.cfg
		b.a if no version tag is found in "git tag", package version = {version in setup.cfg}.dev{total commit number}.
		b.b if version tag is found in "git tag":
 			b.b.a version tag > version in setup.cfg, then raise an error.
			b.b.b version tag = version in setup.cfg:
				b.b.b.a if version tag is tagged on the latest commit, package version = this version number.
				b.b.b.b if version tag is tagged on old commit, then raise an error.
			b.b.c version tag < version in setup.cfg, package version = {version in setup.cfg}.
Under this circumstance, it's better not to manually modify version number in setup.cfg. Instead, we should create a new version tag when we want to make a release, and let pbr package to read the version from tag.