### PR TITLE
Use UNIX socket for serial

### DIFF
--- a/etc/infrasim.full.yml.example
+++ b/etc/infrasim.full.yml.example
@@ -173,5 +173,5 @@ ipmi_console_port: 9000
 # Used by ipmi_sim and qemu
 bmc_connection_port: 9100
 
-# Used by socat and qemu
-serial_port: 9003
+# Socket file to bridge socat and qemu
+serial_socket: /tmp/serial

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1294,6 +1294,7 @@ class CCompute(Task, CElement):
             self.__element_list.append(pci_topology_manager_obj)
 
         backend_storage_obj = CBackendStorage(self.__compute['storage_backend'])
+        backend_storage_obj.owner = self
         if pci_topology_manager_obj:
             backend_storage_obj.set_pci_topology_mgr(pci_topology_manager_obj)
         self.__element_list.append(backend_storage_obj)

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1169,7 +1169,7 @@ class CCompute(Task, CElement):
 
         # Node wise attributes
         self.__port_qemu_ipmi = 9002
-        self.__port_serial = 9003
+        self.__socket_serial = ""
         self.__sol_enabled = False
         self.__kernel = None
         self.__initrd = None
@@ -1188,8 +1188,8 @@ class CCompute(Task, CElement):
     def set_port_qemu_ipmi(self, port):
         self.__port_qemu_ipmi = port
 
-    def set_port_serial(self, port):
-        self.__port_serial = port
+    def set_socket_serial(self, o):
+        self.__socket_serial = o
 
     def set_smbios(self, smbios):
         self.__smbios = smbios
@@ -1296,7 +1296,6 @@ class CCompute(Task, CElement):
         backend_storage_obj = CBackendStorage(self.__compute['storage_backend'])
         if pci_topology_manager_obj:
             backend_storage_obj.set_pci_topology_mgr(pci_topology_manager_obj)
-        backend_storage_obj.owner = self
         self.__element_list.append(backend_storage_obj)
 
         backend_network_obj = CBackendNetwork(self.__compute['networks'])
@@ -1395,12 +1394,11 @@ class CCompute(Task, CElement):
         if self.__cdrom_file:
             self.add_option("-cdrom {}".format(self.__cdrom_file))
 
-        if self.__port_serial and self.__sol_enabled:
+        if self.__socket_serial and self.__sol_enabled:
             chardev = CCharDev({
-                "backend": "udp",
-                "host": "127.0.0.1",
-                "wait": "off",
-                "port": self.__port_serial
+                "backend": "socket",
+                "path": self.__socket_serial,
+                "wait": "off"
             })
             chardev.set_id("serial0")
             chardev.init()
@@ -1781,11 +1779,11 @@ class CSocat(Task):
         self.__bin = "socat"
 
         # Node wise attributes
-        self.__port_serial = 9003
+        self.__socket_serial = ""
         self.__sol_device = ""
 
-    def set_port_serial(self, port):
-        self.__port_serial = port
+    def set_socket_serial(self, o):
+        self.__socket_serial = o
 
     def set_sol_device(self, device):
         self.__sol_device = device
@@ -1813,10 +1811,17 @@ class CSocat(Task):
         else:
             self.__sol_device = os.path.join(config.infrasim_etc, "pty0")
 
+        if self.__socket_serial:
+            pass
+        elif self.get_workspace():
+            self.__socket_serial = os.path.join(self.get_workspace(), ".serial")
+        else:
+            self.__socket_serial = os.path.join(config.infrasim_etc, "serial")
+
     def get_commandline(self):
         socat_str = "{0} pty,link={1},waitslave " \
-            "udp-listen:{2},reuseaddr,fork".\
-            format(self.__bin, self.__sol_device, self.__port_serial)
+            "unix-listen:{2},fork".\
+            format(self.__bin, self.__sol_device, self.__socket_serial)
 
         return socat_str
 
@@ -1994,13 +1999,17 @@ class CNode(object):
             bmc_obj.set_type(self.__node['type'])
             compute_obj.set_type(self.__node['type'])
 
-        if "sol_device" in self.__node and self.__sol_enabled:
-            socat_obj.set_sol_device(self.__node["sol_device"])
-            bmc_obj.set_sol_device(self.__node["sol_device"])
+        if self.__sol_enabled:
+            if "sol_device" in self.__node:
+                socat_obj.set_sol_device(self.__node["sol_device"])
+                bmc_obj.set_sol_device(self.__node["sol_device"])
 
-        if "serial_port" in self.__node and self.__sol_enabled:
-            socat_obj.set_port_serial(self.__node["serial_port"])
-            compute_obj.set_port_serial(self.__node["serial_port"])
+            if "serial_socket" not in self.__node:
+                self.__node["serial_socket"] = os.path.join(config.infrasim_home,
+                                                            self.__node["name"],
+                                                            ".serial")
+            socat_obj.set_socket_serial(self.__node["serial_socket"])
+            compute_obj.set_socket_serial(self.__node["serial_socket"])
 
         if "ipmi_console_port" in self.__node:
             bmc_obj.set_port_ipmi_console(self.__node["ipmi_console_port"])

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1799,9 +1799,11 @@ class CSocat(Task):
         except CommandRunFailed:
             raise CommandNotFound("socat")
 
-        # check workspace
-        if not self.__sol_device and not self.get_workspace():
-            raise ArgsNotCorrect("No workspace and serial device are defined")
+        if not self.__sol_device:
+            raise ArgsNotCorrect("No SOL device is defined")
+
+        if not self.__socket_serial:
+            raise ArgsNotCorrect("No socket file for serial is defined")
 
     def init(self):
         if self.__sol_device:

--- a/infrasim/qemu.py
+++ b/infrasim/qemu.py
@@ -79,8 +79,8 @@ def start_qemu(conf_file=config.infrasim_default_config):
         else:
             compute.set_type(conf['type'])
 
-        if "serial_port" in conf:
-            compute.set_port_serial(conf["serial_port"])
+        if "serial_socket" in conf:
+            compute.set_socket_serial(conf["serial_socket"])
 
         if "bmc_connection_port" in conf:
             compute.set_port_qemu_ipmi(conf["bmc_connection_port"])
@@ -124,8 +124,8 @@ def stop_qemu(conf_file=config.infrasim_default_config):
         else:
             compute.set_type(conf['type'])
 
-        if "serial_port" in conf:
-            compute.set_port_serial(conf["serial_port"])
+        if "serial_socket" in conf:
+            compute.set_socket_serial(conf["serial_socket"])
 
         if "bmc_connection_port" in conf:
             compute.set_port_qemu_ipmi(conf["bmc_connection_port"])

--- a/infrasim/socat.py
+++ b/infrasim/socat.py
@@ -45,8 +45,8 @@ def start_socat(conf_file=config.infrasim_default_config):
         # and set to socat
         if "sol_device" in conf:
             socat.set_sol_device(conf["sol_device"])
-        if "serial_port" in conf:
-            socat.set_port_serial(conf["serial_port"])
+        if "serial_socket" in conf:
+            socat.set_socket_serial(conf["serial_socket"])
 
         socat.set_workspace(node.workspace.get_workspace())
         socat.init()

--- a/test/functional/test_configuration_change.py
+++ b/test/functional/test_configuration_change.py
@@ -338,9 +338,9 @@ class test_connection(unittest.TestCase):
                                  subprocess.PIPE, subprocess.PIPE)[1]
         assert "port=9102" in str_result
 
-    def test_set_serial_port(self):
+    def test_set_serial_socket(self):
         self.conf["sol"] = True
-        self.conf["serial_port"] = 9103
+        self.conf["serial_socket"] = "/tmp/test_infrasim_set_serial_socket"
 
         node = model.CNode(self.conf)
         node.init()
@@ -349,12 +349,14 @@ class test_connection(unittest.TestCase):
 
         str_result = run_command(PS_QEMU, True,
                                  subprocess.PIPE, subprocess.PIPE)[1]
-        assert "-chardev udp,host=127.0.0.1,port=9103,id=serial0,reconnect=10" in str_result
+        assert "-chardev socket,path=/tmp/test_infrasim_set_serial_socket," \
+               "id=serial0,reconnect=10" in str_result
         assert "-device isa-serial,chardev=serial0" in str_result
 
         str_result = run_command(PS_SOCAT, True,
                                  subprocess.PIPE, subprocess.PIPE)[1]
-        assert "udp-listen:9103,reuseaddr,fork" in str_result
+        assert "unix-listen:/tmp/test_infrasim_set_serial_socket," \
+               "fork" in str_result
 
     def test_set_node_type(self):
         self.conf["type"] = "dell_c6320"

--- a/test/functional/test_main_intf.py
+++ b/test/functional/test_main_intf.py
@@ -36,10 +36,12 @@ class test_start_intf(unittest.TestCase):
 
             assert test_ip_list
 
-            str_result = run_command('hostname -I', True, \
-                                 subprocess.PIPE, subprocess.PIPE)[1]
+            str_result = run_command(
+                'hostname -I', True, subprocess.PIPE, subprocess.PIPE)[1]
 
             host_ip = str_result.split()
+            # remove IPV6 addresses from host ip list
+            host_ip = [ip for ip in host_ip if ":" not in ip]
 
             # Verify IP address, except 127.0.0.1, both lists share
             # same set of ip address

--- a/test/functional/test_node_ports.py
+++ b/test/functional/test_node_ports.py
@@ -115,7 +115,6 @@ class test_node_ports_no_conflict(unittest.TestCase):
         self.node_info_2['ipmi_console_ssh'] = 9301
         self.node_info_2['ipmi_console_port'] = 9001
         self.node_info_2['bmc_connection_port'] = 9101
-        self.node_info_2['serial_port'] = 9004
         self.node_info_2['compute']['vnc_display'] = 2
         self.node_info_2['compute']['monitor'] = {
             'mode': 'readline',

--- a/test/functional/test_serial.py
+++ b/test/functional/test_serial.py
@@ -8,8 +8,12 @@ import os
 import yaml
 from infrasim import socat
 from infrasim import config
+from infrasim import model
 from test import fixtures
 import shutil
+import subprocess
+import time
+import re
 
 """
 Test serial functions:
@@ -64,3 +68,71 @@ class test_serial(unittest.TestCase):
             assert False
         else:
             assert True
+
+
+class test_ipmi_sol(unittest.TestCase):
+
+    def setUp(self):
+        fake_config = fixtures.FakeConfig()
+        self.conf = fake_config.get_node_info()
+        node = model.CNode(self.conf)
+        node.init()
+        node.precheck()
+        node.start()
+        time.sleep(3)
+
+        # Start sol in a subprocess
+        self.fw = open('/tmp/test_sol', 'wb')
+        self.fr = open('/tmp/test_sol', 'r')
+        self.p_sol = subprocess.Popen("ipmitool -I lanplus -U admin -P admin "
+                                      "-H 127.0.0.1 sol activate",
+                                      shell=True,
+                                      stdin=subprocess.PIPE,
+                                      stdout=self.fw,
+                                      stderr=self.fw,
+                                      bufsize=1)
+
+    def tearDown(self):
+        self.fw.close()
+        self.fr.close()
+        self.p_sol.stdin.write("~.")
+        self.p_sol.kill()
+        node = model.CNode(self.conf)
+        node.init()
+        node.stop()
+        node.terminate_workspace()
+        os.remove("/tmp/test_sol")
+        self.conf = None
+
+    def test_ipmi_sol(self):
+        """
+        Activate SOL and verify it accepts serial data
+        """
+        # This method refer to a solution on stackoverflow:
+        # http://stackoverflow.com/questions/19880190/interactive-input-output-using-python
+
+        # Send ipmitool in shell within another sub process
+        # and make sure it's sent correctly
+        p_power = subprocess.Popen("ipmitool -I lanplus -H admin -P admin "
+                                   "-H 127.0.0.1 chassis power reset",
+                                   shell=True,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+        p_power.communicate()
+        p_power_ret = p_power.returncode
+        if p_power_ret != 1:
+            raise self.fail("Fail to send chassis power reset command")
+
+        # Check if sol session has get something
+        time.sleep(10)
+        sol_out = self.fr.read()
+
+        # SOL will print a hint at first
+        # After this hint message, any ASCII char indicates
+        # the SOL receives something and it means SOL is alive
+        deli = "[SOL Session operational.  Use ~? for help]"
+        deli_index = sol_out.find(deli)
+        string_left = sol_out[len(deli)+deli_index:]
+        p = re.compile(r"\w")
+
+        assert p.search(string_left) is not None

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -747,7 +747,27 @@ class socat_configuration(unittest.TestCase):
         cmd = socat_obj.get_commandline()
 
         assert "pty,link={}/pty0,waitslave".format(config.infrasim_etc) in cmd
-        assert "udp-listen:9003,reuseaddr" in cmd
+        assert "unix-listen:{}/serial,fork".format(config.infrasim_etc) in cmd
+
+    def test_change_sol_device(self):
+        socat_obj = model.CSocat()
+
+        socat_obj.set_sol_device("/tmp/sol_device")
+        socat_obj.init()
+        socat_obj.precheck()
+        cmd = socat_obj.get_commandline()
+
+        assert "pty,link=/tmp/sol_device,waitslave".format(config.infrasim_etc) in cmd
+
+    def test_change_serial_socket(self):
+        socat_obj = model.CSocat()
+
+        socat_obj.set_socket_serial("/tmp/serial_socket")
+        socat_obj.init()
+        socat_obj.precheck()
+        cmd = socat_obj.get_commandline()
+
+        assert "unix-listen:/tmp/serial_socket,fork".format(config.infrasim_etc) in cmd
 
 
 class racadm_configuration(unittest.TestCase):


### PR DESCRIPTION
Previously, infrasim use port 9003 by default to forward serial
stream. This leads critical hang on some cloud environment.
Now this is changed to use UNIX socket, and impacts socat and
qemu with the command line option like this:

- socat, `unix-listen:<socket_file>`
- qemu, `-chardeve,socket,path=<socket_file>`

Added test on SOL to verify this data path is available.