### PR TITLE
Change version checking for infrasim

### DIFF
--- a/infrasim/__init__.py
+++ b/infrasim/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess
+import pkg_resources
 
 logger = logging.getLogger()
 hdlr = logging.FileHandler('/var/log/infrasim.log')
@@ -7,6 +8,12 @@ formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
 hdlr.setFormatter(formatter)
 logger.addHandler(hdlr)
 logger.setLevel(logging.NOTSET)
+
+
+try:
+    __version__ = pkg_resources.get_distribution('infrasim-compute').version
+except pkg_resources.DistributionNotFound:
+    __version__ = None
 
 
 def run_command(cmd="", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE):

--- a/infrasim/version.py
+++ b/infrasim/version.py
@@ -1,6 +1,6 @@
 import os
-from yaml_loader import YAMLLoader
 import config
+import infrasim
 from . import ipmi, socat, run_command, qemu
 
 VERSION_CONF = os.path.join(config.infrasim_template, "version.yml")
@@ -17,7 +17,6 @@ def version():
     version_str += "{:<10}: {}\n".format("OpenIPMI", run_command(ipmi_ver_cmd)[1].split('\n')[0])
     version_str += "{:<10}: {}\n".format("Socat",
                                         ' '.join(run_command(socat_ver_cmd)[1].split('\n')[1].split(' ')[0:3]))
-    with open(VERSION_CONF, 'r') as v_yml:
-        version_str += "{:<10}: infrasim-compute version {}\n".format("InfraSIM",
-                                                                     YAMLLoader(v_yml).get_data()["version"])
+
+    version_str += "{:<10}: infrasim-compute version {}\n".format("InfraSIM", infrasim.__version__)
     return version_str

--- a/template/version.yml
+++ b/template/version.yml
@@ -1,3 +1,0 @@
----
-#This file is for infrasim-compute version
-version: 3.0.1 


### PR DESCRIPTION
Previously we have two places for version:
1. version num inside infrasim/version.yml
2. version tag on certain commit in .git

To avoid redundancy and easier to maintain version, we can use
pkg_resources library in setuptools to fetch infrasim-compute version
from working set.

However, this method has a problem:

If you installed several versions of infrasim-compute without
uninstalling the old ones, the version will show the largest version you
installed, not the latest one.

Haven't found solution yet.