### PR TITLE
develop/verify-boot-order-ncd

### DIFF
--- a/etc/infrasim.full.yml.example
+++ b/etc/infrasim.full.yml.example
@@ -26,8 +26,7 @@ name: node-0
 type: quanta_d51
 
 compute:
-    # n - Network (PXE); c - CD-ROM;
-    # d - Drive (bootindex in drive sections controls order of booting HDD)
+    # floppy (a), hard disk (c), CD-ROM (d), network (n)
     boot_order: ncd
     kvm_enabled: true
     numa_control: true

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1384,11 +1384,11 @@ class CCompute(Task, CElement):
                     boot_param = f.readlines()
                 boot_param = boot_param[0].strip()
                 if boot_param == "default":
-                    self.__boot_order = "d"
+                    self.__boot_order = "c"
                 elif boot_param == "pxe":
                     self.__boot_order = "n"
                 elif boot_param == "cdrom":
-                    self.__boot_order = "c"
+                    self.__boot_order = "d"
                 else:
                     self.__boot_order = "ncd"
                 self.add_option("-boot {}".format(self.__boot_order))

--- a/test/functional/test_boot_order.py
+++ b/test/functional/test_boot_order.py
@@ -1,0 +1,85 @@
+'''
+*********************************************************
+Copyright @ 2015 EMC Corporation All Rights Reserved
+*********************************************************
+'''
+import unittest
+from infrasim import model
+from test import fixtures
+import subprocess
+import time
+import re
+import os
+
+class test_boot_order(unittest.TestCase):
+
+    def setUp(self):
+        fake_config = fixtures.FakeConfig()
+        self.conf = fake_config.get_node_info()
+        os.system("touch /tmp/test.iso")
+        self.conf['compute']['cdrom'] = "/tmp/test.iso"
+        self.conf['compute']['boot_order'] = 'ncd'
+        node = model.CNode(self.conf)
+        node.init()
+        node.precheck()
+        node.start()
+        time.sleep(3)
+
+        # Start sol in a subprocess
+        self.fw = open('/tmp/test_sol', 'wb')
+        self.fr = open('/tmp/test_sol', 'r')
+        self.p_sol = subprocess.Popen("ipmitool -I lanplus -U admin -P admin "
+                                      "-H 127.0.0.1 sol activate",
+                                      shell=True,
+                                      stdin=subprocess.PIPE,
+                                      stdout=self.fw,
+                                      stderr=self.fw,
+                                      bufsize=0)
+
+    def tearDown(self):
+        self.fw.close()
+        self.fr.close()
+        self.p_sol.stdin.write("~.")
+        self.p_sol.kill()
+        node = model.CNode(self.conf)
+        node.init()
+        node.stop()
+        node.terminate_workspace()
+        os.remove("/tmp/test_sol")
+        os.remove("/tmp/test.iso")
+        self.conf = None
+
+    def test_boot_order_ncd(self):
+        p_power = subprocess.Popen("ipmitool -I lanplus -H admin -P admin "
+                                   "-H 127.0.0.1 chassis power reset",
+                                   shell=True,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+        p_power.communicate()
+        p_power_ret = p_power.returncode
+        if p_power_ret != 1:
+            raise self.fail("Fail to send chassis power reset command")
+
+        # Check if sol session has get something
+        time.sleep(16)
+        sol_out = self.fr.read()
+        # SOL will print a hint at first
+        # After this hint message, any ASCII char indicates
+        # the SOL receives something and it means SOL is alive
+        p = re.compile(r'\[\d+;\d+H')
+        sol_out = re.sub(p, '', sol_out)
+        p = re.compile(r'\[m')
+        sol_out = re.sub(p, '', sol_out)
+        p = re.compile(r'\[\d+;\d+;lm')
+        sol_out = re.sub(p, '', sol_out)
+        p = re.compile(r'[^A-Za-z0-9 ():/\n.)]')
+        sol_out = re.sub(p, '', sol_out)
+        network_index = sol_out.find('iPXE')
+        disk_index = sol_out.find('Disk')
+        cdrom_index = sol_out.find('DVD/CD')
+        boot_order = True if network_index < disk_index < cdrom_index else False
+
+        assert network_index is not -1
+        assert disk_index is not -1
+        assert cdrom_index is not -1
+        assert boot_order is True


### PR DESCRIPTION
1. Add test to verify the boot order is ncd;
2. The abbreviation is floppy (a), hard disk (c), CD-ROM (d), network (n), which is somewhat different from we thought before. We can use command "qemu-system-x86_64 --help" to see it. Also the related code and notes have been modified.