### PR TITLE
Enable `infrasim config edit`

### DIFF
--- a/infrasim/cli.py
+++ b/infrasim/cli.py
@@ -1,6 +1,7 @@
 import sys
 import time
 import argparse
+import os
 from functools import wraps
 import inspect
 import infrasim.model as model
@@ -65,6 +66,22 @@ class ConfigCommands(object):
                   "You can run commands: \n" \
                   "    infrasim node destroy {0}\n" \
                   "    infrasim node start {0}".format(node_name)
+
+    @args("node_name", nargs='?', default="default",
+          help="Specify node name to open its configuration in editor")
+    def edit(self, node_name):
+        if node_name not in nm.get_name_list():
+            print "Fail to find node {0} configuration. It is not registered. Check by:\n" \
+                  "    infrasim config list".format(node_name)
+            return
+
+        editor = os.environ.get('EDITOR', 'vi')
+        config_path = os.path.join(nm.get_mapping_folder(),
+                                   "{}.yml".format(node_name))
+        try:
+            os.system("{} {}".format(editor, config_path))
+        except OSError, e:
+            print e
 
     def list(self):
         try:

--- a/infrasim/config_manager.py
+++ b/infrasim/config_manager.py
@@ -127,6 +127,7 @@ class NodeMap(object):
         return self.__mapping_folder
 
     def get_name_list(self):
+        self.load()
         return self.__name_list
 
     def get_node_info(self, node_name):

--- a/test/functional/test_cli_commands.py
+++ b/test/functional/test_cli_commands.py
@@ -9,6 +9,7 @@ Copyright @ 2015 EMC Corporation All Rights Reserved
 import os
 import unittest
 import yaml
+import re
 import infrasim.config as config
 from infrasim import run_command
 from test.fixtures import FakeConfig
@@ -371,6 +372,46 @@ class test_config_cli_without_runtime_node(unittest.TestCase):
         assert "Node {}'s configuration is not defined.".format(self.test_name) in output_start[1]
 
 
+class test_command_navigation(unittest.TestCase):
 
+    def test_infrasim(self):
+        """
+        CLI test: "infrasim -h" navigates next level command usage
+        """
+        p = r'\{([a-zA-Z,]+)\}'
+        cmd_next_level = ["node", "chassis", "config", "init", "version"]
 
+        output = run_command("infrasim -h")[1]
+        r = re.compile(p)
+        m = r.search(output)
+        cmd = m.group(1)
+        cmd_list = cmd.split(',')
+        assert set(cmd_list) == set(cmd_next_level)
 
+    def test_infrasim_node(self):
+        """
+        CLI test: "infrasim node -h" navigates next level command usage
+        """
+        p = r'\{([a-zA-Z,]+)\}'
+        cmd_next_level = ["destroy", "info", "status", "start", "stop", "restart"]
+
+        output = run_command("infrasim node -h")[1]
+        r = re.compile(p)
+        m = r.search(output)
+        cmd = m.group(1)
+        cmd_list = cmd.split(',')
+        assert set(cmd_list) == set(cmd_next_level)
+
+    def test_infrasim_config(self):
+        """
+        CLI test: "infrasim config -h" navigates next level command usage
+        """
+        p = r'\{([a-zA-Z,]+)\}'
+        cmd_next_level = ["add", "delete", "edit", "list", "update"]
+
+        output = run_command("infrasim config -h")[1]
+        r = re.compile(p)
+        m = r.search(output)
+        cmd = m.group(1)
+        cmd_list = cmd.split(',')
+        assert set(cmd_list) == set(cmd_next_level)


### PR DESCRIPTION
Added command line `infrasim config edit <name>` to start an
editor interaction on configuration of node <name>.
It reads user's `EDITOR` from envionroment. If it's not set,
`vi` will be opened as a default editor.

Added test on InfraSIM command line navigation.