### PR TITLE
Enhancements/enhance storage controller and drives

### DIFF
--- a/infrasim/cli.py
+++ b/infrasim/cli.py
@@ -204,7 +204,7 @@ class NodeCommands(object):
             row.append([" " * 17, "device", "mode", "name"])
             for i in range(1, len(node_info_net) + 1):
                 net = node_info_net[i-1]
-	        row.append([" " * 17, net['device'], net['network_mode'], net['network_name']])
+                row.append([" " * 17, net['device'], net['network_mode'], net['network_name']])
             table.add_rows(row)
             print table.draw()
 

--- a/infrasim/cli.py
+++ b/infrasim/cli.py
@@ -216,12 +216,12 @@ class NodeCommands(object):
             row.append([" " * 17, "type", "max drive", "drive size"])
             for i in range(1, len(node_info_stor) + 1):
                 stor = node_info_stor[i - 1]
-                node_info_drives = stor['controller']['drives']
+                node_info_drives = stor['drives']
                 for j in range(1, len(node_info_drives) + 1):
                     drive = node_info_drives[j - 1]
                     if j == 1:
-                        row.append([" " * 17, stor['controller']['type'],
-                                    stor['controller']['max_drive_per_controller'], drive['size']])
+                        row.append([" " * 17, stor['type'],
+                                    stor['max_drive_per_controller'], drive['size']])
                     else:
                         row.append([" " * 17, "", "", drive['size']])
             table.add_rows(row)

--- a/infrasim/cli.py
+++ b/infrasim/cli.py
@@ -204,7 +204,7 @@ class NodeCommands(object):
             row.append([" " * 17, "device", "mode", "name"])
             for i in range(1, len(node_info_net) + 1):
                 net = node_info_net[i-1]
-                row.append([" " * 17, net['device'], net['network_mode'], net['network_name']])
+	        row.append([" " * 17, net['device'], net['network_mode'], net['network_name']])
             table.add_rows(row)
             print table.draw()
 

--- a/infrasim/ipmicons/common.py
+++ b/infrasim/ipmicons/common.py
@@ -76,6 +76,8 @@ def init_env(instance):
     have a plan to give instance name to ipmi-console so that it can be attached to
     target vBMC instance.
     """
+    cur_path = os.environ["PATH"]
+    os.environ["PATH"] = "{}/bin:{}".format(os.environ.get("PYTHONPATH"), cur_path)
     if not Workspace.check_workspace_exists(instance):
         raise IpmiError("Warning: there is no node {} workspace. Please start node {} first.".format(instance, instance))
     output = run_command("infrasim node status")

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -590,9 +590,11 @@ class CBaseDrive(CElement):
             # If user announce drive file in config, use it
             # else create for them.
             disk_file_base = os.path.join(config.infrasim_home, ws)
-            self.__drive_file = os.path.join(disk_file_base, "sd{0}.img".format(chr(97+self.__index)))
+            self.__drive_file = os.path.join(disk_file_base, "disk{0}{1}.img".format(self.__bus, self.__index))
+
 
         if not os.path.exists(self.__drive_file):
+	    logger.info("Creating drive: ".format(self.__drive_file))
             command = "qemu-img create -f qcow2 {0} {1}G".format(self.__drive_file, self.__size)
             try:
                 run_command(command)

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1277,7 +1277,7 @@ class CCompute(Task, CElement):
         self.__smbios = None
         self.__bios = None
         self.__boot_order = None
-        self.__qemu_bin = "/home/robert/github/InfraSIM/qemu/x86_64-softmmu/qemu-system-x86_64"
+        self.__qemu_bin = "qemu-system-x86_64"
         self.__cdrom_file = None
         self.__vendor_type = None
         # remember cpu object

--- a/infrasim/workspace.py
+++ b/infrasim/workspace.py
@@ -69,33 +69,39 @@ class Workspace(object):
             VI. Move emulation data, update identifiers, e.g. S/N
             VII. Move bios.bin
         """
-        if os.path.exists(self.__workspace):
-            shutil.rmtree(self.__workspace)
+        if not os.path.exists(self.__workspace):
+            os.mkdir(self.__workspace)
 
-        # I. Create workspace
-        os.mkdir(self.__workspace)
         # II. Create log folder
         path_log = "/var/log/infrasim/{}".format(self.__workspace_name)
         if not os.path.exists(path_log):
             os.mkdir(path_log)
 
         # III. Create sub folder
-        os.mkdir(os.path.join(self.__workspace, "data"))
-        os.mkdir(os.path.join(self.__workspace, "script"))
-        os.mkdir(os.path.join(self.__workspace, "etc"))
+        data_path = os.path.join(self.__workspace, "data")
+        if not os.path.exists(data_path):
+            os.mkdir(data_path)
+
+        script_path = os.path.join(self.__workspace, "script")
+        if not os.path.exists(script_path):
+            os.mkdir(script_path)
+
+        etc_path = os.path.join(self.__workspace, "etc")
+        if not os.path.exists(etc_path):
+            os.mkdir(etc_path)
 
         # IV. Save infrasim.yml
         yml_file = os.path.join(self.__workspace, "etc/infrasim.yml")
         with open(yml_file, 'w') as fp:
             yaml.dump(self.__node_info, fp, default_flow_style=False)
 
+        node_type = self.__node_info["type"]
         # V. Move emulation data
         # Update identifier accordingly
         path_emu_dst = os.path.join(self.__workspace, "data")
         if has_option(self.__node_info, "bmc", "emu_file"):
             shutil.copy(self.__node_info["bmc"]["emu_file"], path_emu_dst)
-        else:
-            node_type = self.__node_info["type"]
+        elif not os.path.exists(os.path.join(self.__workspace, "{0}/{0}.emu".format(node_type))):
             path_emu_src = os.path.join(config.infrasim_data, "{0}/{0}.emu".format(node_type))
             shutil.copy(path_emu_src, os.path.join(path_emu_dst, "{}.emu".
                                                    format(node_type)))
@@ -104,8 +110,7 @@ class Workspace(object):
         path_bios_dst = os.path.join(self.__workspace, "data")
         if has_option(self.__node_info, "compute", "smbios"):
             shutil.copy(self.__node_info["compute"]["smbios"], path_bios_dst)
-        else:
-            node_type = self.__node_info["type"]
+        elif not os.path.exists(os.path.join(self.__workspace, "{0}/{0}_smbios.bin".format(node_type))):
             path_bios_src = os.path.join(config.infrasim_data,
                                          "{0}/{0}_smbios.bin".format(node_type))
             shutil.copy(path_bios_src, os.path.join(path_emu_dst,

--- a/template/infrasim.yml
+++ b/template/infrasim.yml
@@ -48,7 +48,7 @@ compute:
         #Set drive list and define drive attributes
         -
             type: ahci
-            max_drive_per_controller: 8
+            max_drive_per_controller: 6 
             drives:
             {% for disk in disks %}
             -

--- a/template/infrasim.yml
+++ b/template/infrasim.yml
@@ -47,17 +47,16 @@ compute:
     storage_backend:
         #Set drive list and define drive attributes
         -
-            controller:
-                type: ahci
-                max_drive_per_controller: 8
-                drives:
-                {% for disk in disks %}
-                -
-                    #Set node disk size, the unit is GB.
-                    #The default value is 8GB
-                    #
-                    size: {{ disk['size'] }}
-                {% endfor %}
+            type: ahci
+            max_drive_per_controller: 8
+            drives:
+            {% for disk in disks %}
+            -
+                #Set node disk size, the unit is GB.
+                #The default value is 8GB
+                #
+                size: {{ disk['size'] }}
+            {% endfor %}
 
     networks:
         #Set network list and define drive attributes

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -17,15 +17,13 @@ class FakeConfig(object):
                 },
                 "storage_backend": [
                     {
-                        "controller": {
-                            "type": "ahci",
-                            "max_drive_per_controller": 8,
-                            "drives": [
-                                {
-                                    "size": 8
-                                }
-                            ]
-                        }
+                        "type": "ahci",
+                        "max_drive_per_controller": 6,
+                        "drives": [
+                            {
+                                "size": 8
+                            }
+                        ]
                     }
                 ],
                 "networks": [

--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -23,13 +23,14 @@ class FakeConfig(object):
                             {
                                 "size": 8
                             }
-                        ]
+			]		
                     }
                 ],
                 "networks": [
                     {
                         "network_mode": "nat",
-                        "device": "e1000"
+                        "device": "e1000",
+			"network_name": "dummy0"
                     }
                 ]
             }

--- a/test/functional/test_configuration_change.py
+++ b/test/functional/test_configuration_change.py
@@ -120,7 +120,10 @@ class test_compute_configuration_change(unittest.TestCase):
         self.conf["compute"]["storage_backend"] = [{
             "type": "ahci",
             "max_drive_per_controller": 6,
-            "drives": [{"size": 8}, {"size": 8}]
+            "drives": [
+                {"size": 8, "file": "/tmp/sda.img"},
+                {"size": 8, "file": "/tmp/sdb.img"}
+            ]
         }]
         # with open(TMP_CONF_FILE, "w") as yaml_file:
         #    yaml.dump(self.conf, yaml_file, default_flow_style=False)
@@ -134,8 +137,8 @@ class test_compute_configuration_change(unittest.TestCase):
         qemu_cmdline = open("/proc/{}/cmdline".format(qemu_pid)).read().replace("\x00", " ")
 
         assert "qemu-system-x86_64" in qemu_cmdline
-        assert ".infrasim/sda.img" in qemu_cmdline
-        assert ".infrasim/sdb.img" in qemu_cmdline
+        assert "/tmp/sda.img" in qemu_cmdline
+        assert "/tmp/sdb.img" in qemu_cmdline
         assert "format=qcow2" in qemu_cmdline
 
     def test_qemu_boot_from_disk_img(self):

--- a/test/functional/test_configuration_change.py
+++ b/test/functional/test_configuration_change.py
@@ -50,6 +50,11 @@ def read_buffer(channel):
         time.sleep(1)
     return str_output
 
+def get_qemu_pid(node):
+    for t in node.get_task_list():
+        if isinstance(t, model.CCompute):
+            return t.get_task_pid()
+    return None
 
 class test_compute_configuration_change(unittest.TestCase):
 
@@ -113,11 +118,9 @@ class test_compute_configuration_change(unittest.TestCase):
 
     def test_set_disk_drive(self):
         self.conf["compute"]["storage_backend"] = [{
-            "controller": {
-                "type": "ahci",
-                "max_drive_per_controller": 6,
-                "drives": [{"size": 8}, {"size": 8}]
-            }
+            "type": "ahci",
+            "max_drive_per_controller": 6,
+            "drives": [{"size": 8}, {"size": 8}]
         }]
         # with open(TMP_CONF_FILE, "w") as yaml_file:
         #    yaml.dump(self.conf, yaml_file, default_flow_style=False)
@@ -127,11 +130,13 @@ class test_compute_configuration_change(unittest.TestCase):
         node.precheck()
         node.start()
 
-        str_result = run_command(PS_QEMU, True,
-                                 subprocess.PIPE, subprocess.PIPE)[1]
-        assert "qemu-system-x86_64" in str_result
-        assert ".infrasim/test/sda.img,format=qcow2" in str_result
-        assert ".infrasim/test/sdb.img,format=qcow2" in str_result
+        qemu_pid = get_qemu_pid(node)
+        qemu_cmdline = open("/proc/{}/cmdline".format(qemu_pid)).read().replace("\x00", " ")
+
+        assert "qemu-system-x86_64" in qemu_cmdline
+        assert ".infrasim/sda.img" in qemu_cmdline
+        assert ".infrasim/sdb.img" in qemu_cmdline
+        assert "format=qcow2" in qemu_cmdline
 
     def test_qemu_boot_from_disk_img(self):
         MD5_CIRROS_IMG = "ee1eca47dc88f4879d8a229cc70a07c6"
@@ -145,11 +150,9 @@ class test_compute_configuration_change(unittest.TestCase):
 
 
         self.conf["compute"]["storage_backend"] = [{
-            "controller": {
-                "type": "ahci",
-                "max_drive_per_controller": 6,
-                "drives": [{"size": 8, "file": test_img_file}]
-            }
+            "type": "ahci",
+            "max_drive_per_controller": 6,
+            "drives": [{"size": 8, "file": test_img_file}]
         }]
         # with open(TMP_CONF_FILE, "w") as yaml_file:
         #    yaml.dump(self.conf, yaml_file, default_flow_style=False)

--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -71,6 +71,10 @@ def reset_console(channel, timeout=10):
 
 class test_ipmi_console_start_stop(unittest.TestCase):
 
+    def setUp(self):
+        old_path = os.environ.get("PATH")
+        os.environ["PATH"] = "{}/bin:{}".format(os.environ.get("PYTHONPATH"), old_path)
+
     def tearDown(self):
         os.system("infrasim node destroy {}".format(self.node_name))
         os.system("rm -rf {}".format(self.node_workspace))

--- a/test/functional/test_ipmi_kcs_smbios.py
+++ b/test/functional/test_ipmi_kcs_smbios.py
@@ -72,11 +72,9 @@ def start_node(node_type):
     conf = fake_config.get_node_info()
     conf["type"] = node_type
     conf["compute"]["storage_backend"] = [{
-        "controller": {
-            "type": "ahci",
-            "max_drive_per_controller": 6,
-            "drives": [{"size": 8, "file": test_img_file}]
-        }
+        "type": "ahci",
+        "max_drive_per_controller": 6,
+        "drives": [{"size": 8, "file": test_img_file}]
     }]
 
     with open(tmp_conf_file, "w") as yaml_file:

--- a/test/functional/test_node_ports.py
+++ b/test/functional/test_node_ports.py
@@ -1,6 +1,7 @@
 import unittest
 import subprocess
 import time
+import os
 from nose.tools import raises, assert_raises
 from test import fixtures
 from infrasim import model
@@ -12,7 +13,8 @@ from infrasim.ipmicons.common import IpmiError
 PS_QEMU = "ps ax | grep qemu"
 PS_IPMI = "ps ax | grep ipmi"
 PS_SOCAT = "ps ax | grep socat"
-
+old_path = os.environ.get("PATH")
+new_path = "{}/bin:{}".format(os.environ.get("PYTHONPATH"), old_path)
 
 class test_node_ports(unittest.TestCase):
 
@@ -26,6 +28,7 @@ class test_node_ports(unittest.TestCase):
         node.stop()
         node.terminate_workspace()
         self.node_info = None
+        os.environ["PATH"] = old_path
 
     @raises(ArgsNotCorrect)
     def test_qemu_ipmi_port_in_use(self):
@@ -79,6 +82,7 @@ class test_node_ports_no_conflict(unittest.TestCase):
         fake_config_2 = fixtures.FakeConfig()
         self.node_info = fake_config.get_node_info()
         self.node_info_2 = fake_config_2.get_node_info()
+        os.environ["PATH"] = new_path
 
     def tearDown(self):
         node = model.CNode(self.node_info)
@@ -151,6 +155,7 @@ class test_start_node_with_conflict_port(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        os.environ["PATH"] = new_path
         fake_config = fixtures.FakeConfig()
         cls.node_info = fake_config.get_node_info()
 
@@ -169,6 +174,7 @@ class test_start_node_with_conflict_port(unittest.TestCase):
         node.stop()
         node.terminate_workspace()
         cls.node_info = None
+        os.environ["PATH"] = old_path
 
     def setUp(self):
         fake_config_2 = fixtures.FakeConfig()

--- a/test/functional/test_start_stop.py
+++ b/test/functional/test_start_stop.py
@@ -62,7 +62,7 @@ def check_node_start_workspace(node_name):
 
     # Check disk image exist
     node_name = conf["name"]
-    node_drive = conf['compute']['storage_backend'][0]['controller']['drives']
+    node_drive = conf['compute']['storage_backend'][0]['drives']
     for i in range(1, len(node_drive) + 1):
         disk_file = os.path.join(node_root, "sd{0}.img".format(chr(96 + i)))
         assert os.path.exists(disk_file) is True
@@ -125,7 +125,7 @@ def check_node_stop_workspace(node_name):
     node_stor = conf['compute']['storage_backend']
     disk_index = 0
     for stor_control in node_stor:
-        for drive in stor_control:
+        for drive in stor_control["drives"]:
             disk_file = os.path.join(node_root, "sd{0}.img".format(chr(97 + disk_index)))
             disk_index += 1
             assert os.path.exists(disk_file) is True
@@ -134,9 +134,10 @@ def check_node_stop_workspace(node_name):
     serial_dev = os.path.join(node_root, ".pty0")
     assert os.path.exists(serial_dev) is False
 
+    # should __NOT__ check .serial, since it will not be removed automatically
     # Check unix socket file
-    serial = os.path.join(node_root, ".serial")
-    assert os.path.exists(serial) is False
+    # serial = os.path.join(node_root, ".serial")
+    # assert os.path.exists(serial) is False
 
     # Check node runtime pid file don't exist
     node_socat = os.path.join(node_root, ".{}-socat.pid".format(node_name))

--- a/test/functional/test_start_stop.py
+++ b/test/functional/test_start_stop.py
@@ -6,6 +6,7 @@ Copyright @ 2015 EMC Corporation All Rights Reserved
 
 import unittest
 import os
+import yaml
 from infrasim import model
 from infrasim import config
 from infrasim import run_command
@@ -63,6 +64,8 @@ def check_node_start_workspace(node_name):
     # Check disk image exist
     node_name = conf["name"]
     node_drive = conf['compute']['storage_backend'][0]['drives']
+
+    # set drive 'file'
     for i in range(1, len(node_drive) + 1):
         disk_file = os.path.join(node_root, "sd{0}.img".format(chr(96 + i)))
         assert os.path.exists(disk_file) is True
@@ -148,6 +151,7 @@ def check_node_stop_workspace(node_name):
     assert os.path.exists(node_qemu) is False
 
 
+
 class test_control_by_lib(unittest.TestCase):
 
     @classmethod
@@ -155,7 +159,37 @@ class test_control_by_lib(unittest.TestCase):
         fake_config = fixtures.FakeConfig()
         cls.conf = fake_config.get_node_info()
         cls.node_root = os.path.join(config.infrasim_home, cls.conf["name"])
+        
+        # Add several strage controllers and drives to node config file.
+	drives = []
+        drives.append({'size': 8, 'file': "{}/sdb.img".format(cls.node_root)})
+        drives.append({'size': 8, 'file': "{}/sdc.img".format(cls.node_root)})
+        drives.append({'size': 8, 'file': "{}/sdd.img".format(cls.node_root)})
+        drives.append({'size': 8, 'file': "{}/sde.img".format(cls.node_root)})
+        drives.append({'size': 8, 'file': "{}/sdf.img".format(cls.node_root)})
+        cls.conf['compute']['storage_backend'][0]['drives'].extend(drives)
+        cls.conf['compute']['storage_backend'][0]['drives'][0]['file'] = "{}/sda.img".format(cls.node_root)
 
+        controllers = []
+        controllers.append({'type': 'ahci', 'drives': [], 'max_drive_per_controller': 6})
+        controllers.append({'type': 'ahci', 'drives': [], 'max_drive_per_controller': 6})
+        cls.conf['compute']['storage_backend'].extend(controllers)
+
+        drives1 = []
+        drives1.append({'size': 8, 'file': "{}/sdg.img".format(cls.node_root)})
+        drives1.append({'size': 8, 'file': "{}/sdh.img".format(cls.node_root)})
+        cls.conf['compute']['storage_backend'][1]['drives'].extend(drives1)
+
+        drives2 = []
+        drives2.append({'size': 8, 'file': "{}/sdi.img".format(cls.node_root)})
+        drives2.append({'size': 8, 'file': "{}/sdj.img".format(cls.node_root)})
+        cls.conf['compute']['storage_backend'][2]['drives'].extend(drives2)
+
+        with open ('/tmp/test.yml', 'w') as outfile:
+            yaml.dump(cls.conf, outfile, default_flow_style=False)
+
+        os.system("infrasim config add test /tmp/test.yml")
+        
     @classmethod
     def tearDownClass(cls):
         node = model.CNode(cls.conf)
@@ -215,19 +249,59 @@ class test_control_by_lib(unittest.TestCase):
 
 class test_control_by_cli(unittest.TestCase):
 
-    node_name = "default"
+    node_name = "test"
     node_workspace = os.path.join(config.infrasim_home, node_name)
 
+    fake_config = fixtures.FakeConfig()
+    test_config = fake_config.get_node_info()
+    image_path =  "{}/{}".format(config.infrasim_home, node_name)
+    
+    #Add several storage controllers/drives in node config file.
+    drives = []
+    drives.append({'size': 8, 'file': "{}/sdb.img".format(image_path)})
+    drives.append({'size': 8, 'file': "{}/sdc.img".format(image_path)})
+    drives.append({'size': 8, 'file': "{}/sdd.img".format(image_path)})
+    drives.append({'size': 8, 'file': "{}/sde.img".format(image_path)})
+    drives.append({'size': 8, 'file': "{}/sdf.img".format(image_path)})
+    test_config['compute']['storage_backend'][0]['drives'].extend(drives)
+    test_config['compute']['storage_backend'][0]['drives'][0]['file'] = "{}/sda.img".format(image_path)
+
+    controllers = []
+    controllers.append({'type': 'ahci', 'drives': [], 'max_drive_per_controller': 6})
+    controllers.append({'type': 'ahci', 'drives': [], 'max_drive_per_controller': 6})
+    test_config['compute']['storage_backend'].extend(controllers)
+    #print test_config['compute']['storage_backend']
+
+    drives1 = []
+    drives1.append({'size': 8, 'file': "{}/sdg.img".format(image_path)})
+    drives1.append({'size': 8, 'file': "{}/sdh.img".format(image_path)})
+    test_config['compute']['storage_backend'][1]['drives'].extend(drives1)
+
+    drives2 = []
+    drives2.append({'size': 8, 'file': "{}/sdi.img".format(image_path)})
+    drives2.append({'size': 8, 'file': "{}/sdj.img".format(image_path)})
+    test_config['compute']['storage_backend'][2]['drives'].extend(drives2)
+    #print test_config
+
+    with open ('/tmp/test.yml', 'w') as outfile:
+        yaml.dump(test_config, outfile, default_flow_style=False)
+
+    os.system("infrasim config add test /tmp/test.yml")
+
+
+
     def tearDown(self):
-        os.system("infrasim node destroy {}".format(self.node_name))
+       	os.system("infrasim node destroy {}".format(self.node_name))
+	os.system("infrasim config delete {}".format(self.node_name))
         os.system("rm -rf {}".format(self.node_workspace))
         os.system("pkill socat")
         os.system("pkill ipmi")
         os.system("pkill qemu")
 
+    
     def test_normal_start_stop(self):
 
-        run_command("infrasim node start")
+        run_command("infrasim node start {}".format(self.node_name))
 
         # Check workspace
         check_node_start_workspace(self.node_name)
@@ -251,7 +325,7 @@ class test_control_by_cli(unittest.TestCase):
             pid_qemu = fp.read()
             self.assertTrue(os.path.exists("/proc/{}".format(pid_qemu)))
 
-        run_command("infrasim node stop")
+        run_command("infrasim node stop {}".format(self.node_name))
 
         # Check workspace
         check_node_stop_workspace(self.node_name)

--- a/test/functional/test_start_stop.py
+++ b/test/functional/test_start_stop.py
@@ -185,7 +185,7 @@ class test_control_by_lib(unittest.TestCase):
         drives2.append({'size': 8, 'file': "{}/sdj.img".format(cls.node_root)})
         cls.conf['compute']['storage_backend'][2]['drives'].extend(drives2)
 
-        with open ('/tmp/test.yml', 'w') as outfile:
+        with open('/tmp/test.yml', 'w') as outfile:
             yaml.dump(cls.conf, outfile, default_flow_style=False)
 
         os.system("infrasim config add test /tmp/test.yml")
@@ -256,7 +256,7 @@ class test_control_by_cli(unittest.TestCase):
     test_config = fake_config.get_node_info()
     image_path =  "{}/{}".format(config.infrasim_home, node_name)
     
-    #Add several storage controllers/drives in node config file.
+    # Add several storage controllers/drives in node config file.
     drives = []
     drives.append({'size': 8, 'file': "{}/sdb.img".format(image_path)})
     drives.append({'size': 8, 'file': "{}/sdc.img".format(image_path)})
@@ -270,7 +270,6 @@ class test_control_by_cli(unittest.TestCase):
     controllers.append({'type': 'ahci', 'drives': [], 'max_drive_per_controller': 6})
     controllers.append({'type': 'ahci', 'drives': [], 'max_drive_per_controller': 6})
     test_config['compute']['storage_backend'].extend(controllers)
-    #print test_config['compute']['storage_backend']
 
     drives1 = []
     drives1.append({'size': 8, 'file': "{}/sdg.img".format(image_path)})
@@ -281,9 +280,8 @@ class test_control_by_cli(unittest.TestCase):
     drives2.append({'size': 8, 'file': "{}/sdi.img".format(image_path)})
     drives2.append({'size': 8, 'file': "{}/sdj.img".format(image_path)})
     test_config['compute']['storage_backend'][2]['drives'].extend(drives2)
-    #print test_config
 
-    with open ('/tmp/test.yml', 'w') as outfile:
+    with open('/tmp/test.yml', 'w') as outfile:
         yaml.dump(test_config, outfile, default_flow_style=False)
 
     os.system("infrasim config add test /tmp/test.yml")
@@ -291,14 +289,13 @@ class test_control_by_cli(unittest.TestCase):
 
 
     def tearDown(self):
-       	os.system("infrasim node destroy {}".format(self.node_name))
-	os.system("infrasim config delete {}".format(self.node_name))
+        os.system("infrasim node destroy {}".format(self.node_name))
+        os.system("infrasim config delete {}".format(self.node_name))
         os.system("rm -rf {}".format(self.node_workspace))
         os.system("pkill socat")
         os.system("pkill ipmi")
         os.system("pkill qemu")
 
-    
     def test_normal_start_stop(self):
 
         run_command("infrasim node start {}".format(self.node_name))

--- a/test/functional/test_with_bridge.py
+++ b/test/functional/test_with_bridge.py
@@ -215,11 +215,9 @@ class test_bmc_interface_with_bridge(unittest.TestCase):
         fake_config = fixtures.FakeConfig()
         self.conf = fake_config.get_node_info()
         self.conf["compute"]["storage_backend"] = [{
-            "controller": {
-                "type": "ahci",
-                "max_drive_per_controller": 6,
-                "drives": [{"file": "/tmp/kcs.img"}]
-            }
+            "type": "ahci",
+            "max_drive_per_controller": 6,
+            "drives": [{"file": "/tmp/kcs.img"}]
         }]
 
     def tearDown(self):

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -13,6 +13,7 @@ from infrasim import socat
 from infrasim import config
 from infrasim import helper
 from test import fixtures
+from nose.tools import raises
 
 TMP_CONF_FILE = "/tmp/test.yml"
 
@@ -102,11 +103,9 @@ class qemu_functions(unittest.TestCase):
     def test_set_ahci_storage_controller(self):
         try:
             backend_storage_info = [{
-                "controller": {
-                    "type": "ahci",
-                    "max_drive_per_controller": 6,
-                    "drives": [{"size": 8, "file": "/tmp/sda.img"}]
-                }
+                "type": "ahci",
+                "max_drive_per_controller": 6,
+                "drives": [{"size": 8}]
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()
@@ -116,50 +115,70 @@ class qemu_functions(unittest.TestCase):
         except:
             assert False
 
-    def test_set_scsi_storage_controller(self):
+    def test_set_lsi_storage_controller(self):
         try:
             backend_storage_info = [{
-                "controller": {
-                    "type": "scsi",
-                    "max_drive_per_controller": 8,
-                    "drives": [{"size": 8, "file": "/tmp/sda.img"}]
-                }
+                "type": "lsi",
+                "max_drive_per_controller": 6,
+                "drives": [{"size": 8}]
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()
             storage.precheck()
             storage.handle_parms()
-            assert "-device scsi" in storage.get_option()
+            assert "-device lsi" in storage.get_option()
         except:
             assert False
+
+    def test_set_megasas_storage_controller(self):
+        try:
+            backend_storage_info = [{
+                "type": "megasas",
+                "max_drive_per_controller": 6,
+                "drives": [{"size": 8}]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+            storage.handle_parms()
+            assert "-device megasas" in storage.get_option()
+        except:
+            assert False
+
+    @raises(ArgsNotCorrect)
+    def test_unsupported_storage_controller(self):
+        backend_storage_info = [{
+            "type": "scsi",
+            "max_drive_per_controller": 8,
+            "drives": [{"size": 8}]
+        }]
+        storage = model.CBackendStorage(backend_storage_info)
+        storage.init()
+        storage.precheck()
+        storage.handle_parms()
+        assert "-device scsi" in storage.get_option()
 
     def test_set_ahci_storage_controller_2x(self):
         try:
             backend_storage_info = [{
-                "controller": {
-                    "type": "ahci",
-                    "max_drive_per_controller": 2,
-                    "drives": [{"size": 8, "file": "/tmp/sda.img"},
-                               {"size": 8, "file": "/tmp/sda.img"},
-                               {"size": 8, "file": "/tmp/sda.img"}]
-                }
+                "type": "ahci",
+                "max_drive_per_controller": 2,
+                "drives": [{"size": 8}, {"size": 8}, {"size": 8}]
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()
             storage.precheck()
             storage.handle_parms()
-            assert "sata1.2" in storage.get_option()
+            assert "sata1.0" in storage.get_option()
         except:
             assert False
 
     def test_set_ahci_drive_model(self):
         try:
             backend_storage_info = [{
-                "controller": {
-                    "type": "ahci",
-                    "max_drive_per_controller": 6,
-                    "drives": [{"size": 8, "file": "/tmp/sda.img", "model": "SATADOM"}]
-                }
+                "type": "ahci",
+                "max_drive_per_controller": 6,
+                "drives": [{"size": 8, "model": "SATADOM"}]
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()
@@ -172,14 +191,11 @@ class qemu_functions(unittest.TestCase):
     def test_set_ahci_drive_serial(self):
         try:
             backend_storage_info = [{
-                "controller": {
-                    "type": "ahci",
-                    "max_drive_per_controller": 6,
-                    "drives": [
-                        {"size": 8, "file": "/tmp/sda.img",
-                         "model": "SATADOM", "serial": "HUSMM442"}
-                    ]
-                }
+                "type": "ahci",
+                "max_drive_per_controller": 6,
+                "drives": [
+                    {"size": 8, "model": "SATADOM", "serial": "HUSMM442"}
+                ]
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()
@@ -192,14 +208,11 @@ class qemu_functions(unittest.TestCase):
     def test_set_scsi_drive_vender(self):
         try:
             backend_storage_info = [{
-                "controller": {
-                    "type": "megasas-gen2",
-                    "max_drive_per_controller": 6,
-                    "drives": [
-                        {"size": 8, "file": "/tmp/sda.img",
-                         "serial": "HUSMM442", "model": "SATADOM",
-                         "vendor": "Hitachi"}],
-                }
+                "type": "megasas-gen2",
+                "max_drive_per_controller": 6,
+                "drives": [
+                    {"size": 8, "serial": "HUSMM442",
+                        "model": "SATADOM", "vendor": "Hitachi"}],
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()
@@ -212,15 +225,13 @@ class qemu_functions(unittest.TestCase):
     def test_set_scsi_drive_rotation(self):
         try:
             backend_storage_info = [{
-                "controller": {
-                    "type": "megasas-gen2",
-                    "max_drive_per_controller": 6,
-                    "drives": [{
-                        "size": 8, "file": "/tmp/sda.img",
-                        "model": "SATADOM", "serial": "HUSMM442",
-                        "vendor": "Hitachi", "rotation": 1
-                    }]
-                }
+                "type": "megasas-gen2",
+                "max_drive_per_controller": 6,
+                "drives": [{
+                    "size": 8, "model": "SATADOM",
+                    "serial": "HUSMM442", "vendor": "Hitachi",
+                    "rotation": 1
+                }]
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()
@@ -233,15 +244,12 @@ class qemu_functions(unittest.TestCase):
     def test_set_scsi_drive_product(self):
         try:
             backend_storage_info = [{
-                "controller": {
-                    "type": "megasas-gen2",
-                    "max_drive_per_controller": 6,
-                    "drives": [{
-                        "size": 8, "file": "/tmp/sda.img",
-                        "model": "SATADOM", "serial": "HUSMM442",
-                        "vendor": "Hitachi", "rotation": 1,
-                        "product": "Quanta"}]
-                }
+                "type": "megasas-gen2",
+                "max_drive_per_controller": 6,
+                "drives": [{
+                        "size": 8, "model": "SATADOM",
+                        "serial": "HUSMM442", "vendor": "Hitachi",
+                        "rotation": 1, "product": "Quanta"}]
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -180,7 +180,9 @@ class qemu_functions(unittest.TestCase):
             backend_storage_info = [{
                 "type": "ahci",
                 "max_drive_per_controller": 6,
-                "drives": [{"size": 8, "model": "SATADOM", "file": "/tmp/sda.img"}]
+                "drives": [{"size": 8, 
+                            "model": "SATADOM", 
+                            "file": "/tmp/sda.img"}]
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()
@@ -270,7 +272,8 @@ class qemu_functions(unittest.TestCase):
 
         compute_info["smbios"] = "/tmp/test.smbios"
         compute = model.CCompute(compute_info)
-        compute.set_workspace("{}/{}".format(config.infrasim_home, node_info['name']))
+        compute.set_workspace("{}/{}".format(config.infrasim_home, 
+                                             node_info['name']))
         compute.init()
         assert compute.get_smbios() == "/tmp/test.smbios"
 

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -105,7 +105,7 @@ class qemu_functions(unittest.TestCase):
             backend_storage_info = [{
                 "type": "ahci",
                 "max_drive_per_controller": 6,
-                "drives": [{"size": 8}]
+                "drives": [{"size": 8, "file": "/tmp/sda.img"}]
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()
@@ -120,7 +120,7 @@ class qemu_functions(unittest.TestCase):
             backend_storage_info = [{
                 "type": "lsi",
                 "max_drive_per_controller": 6,
-                "drives": [{"size": 8}]
+                "drives": [{"size": 8, "file": "/tmp/sda.img"}]
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()
@@ -135,7 +135,7 @@ class qemu_functions(unittest.TestCase):
             backend_storage_info = [{
                 "type": "megasas",
                 "max_drive_per_controller": 6,
-                "drives": [{"size": 8}]
+                "drives": [{"size": 8, "file": "/tmp/sda.img"}]
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()
@@ -150,7 +150,7 @@ class qemu_functions(unittest.TestCase):
         backend_storage_info = [{
             "type": "scsi",
             "max_drive_per_controller": 8,
-            "drives": [{"size": 8}]
+            "drives": [{"size": 8, "file": "/tmp/sda.img"}]
         }]
         storage = model.CBackendStorage(backend_storage_info)
         storage.init()
@@ -163,7 +163,9 @@ class qemu_functions(unittest.TestCase):
             backend_storage_info = [{
                 "type": "ahci",
                 "max_drive_per_controller": 2,
-                "drives": [{"size": 8}, {"size": 8}, {"size": 8}]
+                "drives": [{"size": 8, "file": "/tmp/sda.img"},
+                           {"size": 8, "file": "/tmp/sdb.img"},
+                           {"size": 8, "file": "/tmp/sdc.img"}]
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()
@@ -178,7 +180,7 @@ class qemu_functions(unittest.TestCase):
             backend_storage_info = [{
                 "type": "ahci",
                 "max_drive_per_controller": 6,
-                "drives": [{"size": 8, "model": "SATADOM"}]
+                "drives": [{"size": 8, "model": "SATADOM", "file": "/tmp/sda.img"}]
             }]
             storage = model.CBackendStorage(backend_storage_info)
             storage.init()
@@ -194,7 +196,8 @@ class qemu_functions(unittest.TestCase):
                 "type": "ahci",
                 "max_drive_per_controller": 6,
                 "drives": [
-                    {"size": 8, "model": "SATADOM", "serial": "HUSMM442"}
+                    {"size": 8, "file": "/tmp/sda.img",
+                     "model": "SATADOM", "serial": "HUSMM442"}
                 ]
             }]
             storage = model.CBackendStorage(backend_storage_info)
@@ -211,7 +214,7 @@ class qemu_functions(unittest.TestCase):
                 "type": "megasas-gen2",
                 "max_drive_per_controller": 6,
                 "drives": [
-                    {"size": 8, "serial": "HUSMM442",
+                    {"size": 8, "serial": "HUSMM442", "file": "/tmp/sda.img",
                         "model": "SATADOM", "vendor": "Hitachi"}],
             }]
             storage = model.CBackendStorage(backend_storage_info)
@@ -230,7 +233,7 @@ class qemu_functions(unittest.TestCase):
                 "drives": [{
                     "size": 8, "model": "SATADOM",
                     "serial": "HUSMM442", "vendor": "Hitachi",
-                    "rotation": 1
+                    "rotation": 1, "file": "/tmp/sda.img"
                 }]
             }]
             storage = model.CBackendStorage(backend_storage_info)
@@ -247,7 +250,7 @@ class qemu_functions(unittest.TestCase):
                 "type": "megasas-gen2",
                 "max_drive_per_controller": 6,
                 "drives": [{
-                        "size": 8, "model": "SATADOM",
+                        "size": 8, "model": "SATADOM", "file": "/tmp/sda.img",
                         "serial": "HUSMM442", "vendor": "Hitachi",
                         "rotation": 1, "product": "Quanta"}]
             }]
@@ -261,12 +264,13 @@ class qemu_functions(unittest.TestCase):
 
     def test_set_smbios(self):
         with open(config.infrasim_default_config, "r") as f_yml:
-            compute_info = yaml.load(f_yml)["compute"]
-        workspace = os.path.join(os.environ["HOME"], ".infrasim", ".test")
+            node_info = yaml.load(f_yml)
+        compute_info = node_info["compute"]
+        compute_info["smbios"] = "/tmp/test.smbios"
 
         compute_info["smbios"] = "/tmp/test.smbios"
         compute = model.CCompute(compute_info)
-        compute.set_workspace(workspace)
+        compute.set_workspace("{}/{}".format(config.infrasim_home, node_info['name']))
         compute.init()
         assert compute.get_smbios() == "/tmp/test.smbios"
 
@@ -282,9 +286,10 @@ class qemu_functions(unittest.TestCase):
 
     def test_set_smbios_with_type_and_workspace(self):
         with open(config.infrasim_default_config, "r") as f_yml:
-            compute_info = yaml.load(f_yml)["compute"]
-        workspace = os.path.join(os.environ["HOME"], ".infrasim", ".test")
+            node_info = yaml.load(f_yml)
+        compute_info = node_info["compute"]
 
+        workspace = "{}/{}".format(config.infrasim_home, node_info['name'])
         compute = model.CCompute(compute_info)
         compute.set_type("s2600kp")
         compute.set_workspace(workspace)


### PR DESCRIPTION
@xiar @turtle-fly @XiaowenJiang @WinnieXU1 @fub2 
This new pull request is for Robert's PR #185 which supports multiple storage controllers and max 6 drives per controller. Below  storage drives configuration example in a node has been tested. Will add specific storage test later.
  ```
storage_backend:
  - drives:
    - file: /home/infrasim/.infrasim/test/sda.img
      size: 8
    - file: /home/infrasim/.infrasim/test/sdb.img
      size: 8
    - file: /home/infrasim/.infrasim/test/sdc.img
      size: 8
    - file: /home/infrasim/.infrasim/test/sdd.img
      size: 8
    - file: /home/infrasim/.infrasim/test/sde.img
      size: 8
    - file: /home/infrasim/.infrasim/test/sdf.img
      size: 8
    max_drive_per_controller: 6
    type: ahci
  - drives:
    - file: /home/infrasim/.infrasim/test/sdg.img
      size: 8
    - file: /home/infrasim/.infrasim/test/sdh.img
      size: 8
    max_drive_per_controller: 6
    type: ahci
  - drives:
    - file: /home/infrasim/.infrasim/test/sdi.img
      size: 8
    - file: /home/infrasim/.infrasim/test/sdj.img
      size: 8
    max_drive_per_controller: 6
    type: ahci
```
