### PR TITLE
Fix controller drive attributes error

### DIFF
--- a/etc/infrasim.full.yml.example
+++ b/etc/infrasim.full.yml.example
@@ -58,56 +58,56 @@ compute:
             max_drive_per_controller: 6
             drives:
                 -
-                     model: SATADOM
-                     serial: HUSMM142
-                     bootindex: 1
-                     # To boot esxi, please set ignore_msrs to Y
-                     # sudo -i
-                     # echo 1 > /sys/module/kvm/parameters/ignore_msrs
-                     # cat /sys/module/kvm/parameters/ignore_msrs
-                     file: chassis/node1/esxi6u2-1.qcow2
+                    model: SATADOM
+                    serial: HUSMM142
+                    bootindex: 1
+                    # To boot esxi, please set ignore_msrs to Y
+                    # sudo -i
+                    # echo 1 > /sys/module/kvm/parameters/ignore_msrs
+                    # cat /sys/module/kvm/parameters/ignore_msrs
+                    file: chassis/node1/esxi6u2-1.qcow2
                 -
-                     vendor: Hitachi
-                     model: HUSMM0SSD
-                     serial: 0SV3XMUA
-                     # To set rotation to 1 (SSD), need some customization
-                     # on qemu
-                     # rotation: 1
-                     # Use RAM-disk to accelerate IO
-                     file: /dev/ram0
+                    vendor: Hitachi
+                    model: HUSMM0SSD
+                    serial: 0SV3XMUA
+                    # To set rotation to 1 (SSD), need some customization
+                    # on qemu
+                    # rotation: 1
+                    # Use RAM-disk to accelerate IO
+                    file: /dev/ram0
                 -
-                     vendor: Samsung
-                     model: SM162521
-                     serial: S0351X2B
-                     # Create your disk image first
-                     # e.g. qemu-img create -f qcow2 sda.img 2G
-                     file: chassis/node1/sda.img
+                    vendor: Samsung
+                    model: SM162521
+                    serial: S0351X2B
+                    # Create your disk image first
+                    # e.g. qemu-img create -f qcow2 sda.img 2G
+                    file: chassis/node1/sda.img
                 -
-                     vendor: Samsung
-                     model: SM162521
-                     serial: S0351X3B
-                     file: chassis/node1/sdb.img
+                    vendor: Samsung
+                    model: SM162521
+                    serial: S0351X3B
+                    file: chassis/node1/sdb.img
                 -
-                     vendor: Samsung
-                     model: SM162521
-                     serial: S0451X2B
-                     file: chassis/node1/sdc.img
+                    vendor: Samsung
+                    model: SM162521
+                    serial: S0451X2B
+                    file: chassis/node1/sdc.img
         -
             type: megasas-gen2
             use_jbod: true
             use_msi: true
             max_cmds: 1024
-            max-sge: 128
+            max_sge: 128
             max_drive_per_controller: 1
             drives:
-                    -
-                        vendor: HITACHI
-                        product: HUSMM168XXXXX
-                        serial: SN0500010351XXX
-                        rotation: 1
-                        slot_number: 0
-                        wwn: 0x50000ccaxxxxxxxx
-                        file: <path/to/your disk file>
+                -
+                    vendor: Hitachi
+                    product: HUSMM168XXXXX
+                    serial: SN0500010351XXX
+                    rotation: 1
+                    slot_number: 0
+                    wwn: 0x50000ccaxxxxxxxx
+                    file: <path/to/your disk file>
 
     networks:
         -

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -404,6 +404,8 @@ class MegaSASController(CBaseStorageController):
         self.__sas_address = self._controller_info.get('sas_address')
         self.__max_cmds = self._controller_info.get('max_cmds')
         self.__max_sge = self._controller_info.get('max_sge')
+        self.__use_msi = self._controller_info.get('use_msi')
+        self.__use_jbod = self._controller_info.get('use_jbod')
 
         self._start_idx = self.controller_index
         idx = 0
@@ -519,7 +521,6 @@ class CBaseDrive(CElement):
         self.__index = 0
         self.__serial = None
         self.__wwn = None
-        self.__drive_file = None
         self.__bootindex = None
         self.__bus_address = None
         self.__version = None
@@ -592,9 +593,8 @@ class CBaseDrive(CElement):
             disk_file_base = os.path.join(config.infrasim_home, ws)
             self.__drive_file = os.path.join(disk_file_base, "disk{0}{1}.img".format(self.__bus, self.__index))
 
-
         if not os.path.exists(self.__drive_file):
-	    logger.info("Creating drive: ".format(self.__drive_file))
+            logger.info("Creating drive: ".format(self.__drive_file))
             command = "qemu-img create -f qcow2 {0} {1}G".format(self.__drive_file, self.__size)
             try:
                 run_command(command)

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -135,6 +135,11 @@ class qemu_functions(unittest.TestCase):
             backend_storage_info = [{
                 "type": "megasas",
                 "max_drive_per_controller": 6,
+                "use_jbod": True,
+                "use_msi": True,
+                "max_cmds": 1024,
+                "max_sge": 128,
+                "sas_address": "000abc",
                 "drives": [{"size": 8, "file": "/tmp/sda.img"}]
             }]
             storage = model.CBackendStorage(backend_storage_info)
@@ -142,6 +147,11 @@ class qemu_functions(unittest.TestCase):
             storage.precheck()
             storage.handle_parms()
             assert "-device megasas" in storage.get_option()
+            assert "use_jbod=True" in storage.get_option()
+            assert "use_msi=True" in storage.get_option()
+            assert "max_cmds=1024" in storage.get_option()
+            assert "max_sge=128" in storage.get_option()
+            assert "sas_address=000abc" in storage.get_option()
         except:
             assert False
 
@@ -261,6 +271,120 @@ class qemu_functions(unittest.TestCase):
             storage.precheck()
             storage.handle_parms()
             assert "product" in storage.get_option()
+        except:
+            assert False
+
+    def test_set_scsi_drive_port_index(self):
+        try:
+            backend_storage_info = [{
+                "type": "megasas-gen2",
+                "max_drive_per_controller": 6,
+                "drives": [{
+                    "size": 8,
+                    "file": "/tmp/sda.img",
+                    "port_index": "1"
+                }]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+            storage.handle_parms()
+            assert "port_index=1" in storage.get_option()
+        except:
+            assert False
+
+    def test_set_scsi_drive_port_wwn(self):
+        try:
+            backend_storage_info = [{
+                "type": "megasas-gen2",
+                "max_drive_per_controller": 6,
+                "drives": [{
+                    "size": 8,
+                    "file": "/tmp/sda.img",
+                    "port_wwn": "wwn-000abc"
+                }]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+            storage.handle_parms()
+            assert "port_wwn=wwn-000abc" in storage.get_option()
+        except:
+            assert False
+
+    def test_set_scsi_drive_channel(self):
+        try:
+            backend_storage_info = [{
+                "type": "megasas-gen2",
+                "max_drive_per_controller": 6,
+                "drives": [{
+                    "size": 8,
+                    "file": "/tmp/sda.img",
+                    "channel": "1"
+                }]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+            storage.handle_parms()
+            assert "channel=1" in storage.get_option()
+        except:
+            assert False
+
+    def test_set_scsi_scsiid(self):
+        try:
+            backend_storage_info = [{
+                "type": "megasas-gen2",
+                "max_drive_per_controller": 6,
+                "drives": [{
+                    "size": 8,
+                    "file": "/tmp/sda.img",
+                    "scsi-id": "1"
+                }]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+            storage.handle_parms()
+            assert "scsi-id=1" in storage.get_option()
+        except:
+            assert False
+
+    def test_set_scsi_lun(self):
+        try:
+            backend_storage_info = [{
+                "type": "megasas-gen2",
+                "max_drive_per_controller": 6,
+                "drives": [{
+                    "size": 8,
+                    "file": "/tmp/sda.img",
+                    "lun": "1"
+                }]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+            storage.handle_parms()
+            assert "lun=1" in storage.get_option()
+        except:
+            assert False
+
+    def test_set_scsi_lun(self):
+        try:
+            backend_storage_info = [{
+                "type": "megasas-gen2",
+                "max_drive_per_controller": 6,
+                "drives": [{
+                    "size": 8,
+                    "file": "/tmp/sda.img",
+                    "slot_number": "2"
+                }]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+            storage.handle_parms()
+            assert "slot_number=2" in storage.get_option()
         except:
             assert False
 


### PR DESCRIPTION
Model:
Now recognize `use_jbod` and `use_msi` defined in yml.

Example:
`max-sge` is fixed to `max_sge`.

Added unit test for controller's attributes and drive's attributes.
Verify they can be well collected to qemu command line option.