### PR TITLE
Enhancement/add force parameters to infrasim init

### DIFF
--- a/infrasim/cli.py
+++ b/infrasim/cli.py
@@ -326,6 +326,8 @@ def command_handler():
     init_parser.set_defaults(init="init")
     init_parser.add_argument("-s", "--skip-installation", action="store_true",
                              help="Ignore qemu/openipmi package installation")
+    init_parser.add_argument("-f", "--force", action="store_true", 
+                            help="Destroy existing Nodes")
     init_parser.add_argument("-i", "--infrasim-home", action="store",
                              help="Target infrasim home foler, default $HOME/.infrasim")
     exclusive_group = init_parser.add_mutually_exclusive_group()
@@ -339,7 +341,7 @@ def command_handler():
     args = parser.parse_args(sys.argv[1:])
     if hasattr(args, "init"):
         # Do init
-        infrasim_init(args.type, args.skip_installation, args.infrasim_home, args.config_file)
+        infrasim_init(args.type, args.skip_installation, args.force, args.infrasim_home, args.config_file)
     elif hasattr(args, "version"):
         # Print version
         print version()

--- a/infrasim/init.py
+++ b/infrasim/init.py
@@ -87,7 +87,7 @@ def destroy_existing_nodes():
 
 def check_existing_workspace():
     nodes = os.listdir(config.infrasim_home)
-    if len(nodes)>1:
+    if len(nodes) > 1:
         print "There is node workspace existing.\n" 
         print "If you want to remove it, please run:\n"
         print "\"infrasim init -f \" "

--- a/infrasim/init.py
+++ b/infrasim/init.py
@@ -10,6 +10,7 @@ from infrasim.qemu import get_qemu
 from infrasim.package_install import package_install
 from infrasim import helper
 import config
+import subprocess
 
 mac_base = "00:60:16:"
 
@@ -40,6 +41,11 @@ def init_infrasim_conf(node_type):
     eth_nic = filter(lambda x: x != "lo", nics_list)[0]
     mac = create_mac_address()
     networks.append({"nic": eth_nic, "mac": mac})
+    
+    # create_infrasim_directories
+    if not os.path.exists(config.infrasim_home):
+        os.mkdir(config.infrasim_home)
+        os.mkdir(config.infrasim_node_config_map)
 
     # Prepare default disk
     disks = []
@@ -68,15 +74,31 @@ def update_bridge_cfg():
     bridge_conf_loc = os.path.join(qemu_sys_prefix, "etc/qemu")
     if not os.path.exists(bridge_conf_loc):
         os.mkdir(bridge_conf_loc)
-
     bridge_conf = os.path.join(qemu_sys_prefix, bridge_conf_loc, "bridge.conf")
     with open(bridge_conf, "w") as f:
         f.write("allow all")
 
+def destroy_existing_nodes():
+    nodes = os.listdir(config.infrasim_home)
+    if os.path.exists(config.infrasim_node_config_map):
+        nodes.remove('.node_map')
+    for node in nodes:
+        os.system("infrasim node destroy {}".format(node))
 
-def infrasim_init(node_type="quanta_d51", skip_installation=False, target_home=None, config_file=None):
+def check_existing_workspace():
+    nodes = os.listdir(config.infrasim_home)
+    if len(nodes)>1:
+        print "There is node workspace existing.\n" 
+        print "If you want to remove it, please run:\n"
+        print "\"infrasim init -f \" "
+        exit()
+
+def infrasim_init(node_type="dell_r730", skip_installation=True, force=False, target_home=None, config_file=None):
     try:
-        create_infrasim_directories()
+        if force:
+            destroy_existing_nodes()
+            create_infrasim_directories()
+        
         if not skip_installation:
             install_packages()
             update_bridge_cfg()
@@ -88,6 +110,7 @@ def infrasim_init(node_type="quanta_d51", skip_installation=False, target_home=N
             else:
                 raise Exception("{} not found.".format(config_file))
         else:
+            check_existing_workspace()
             init_infrasim_conf(node_type)
 
         get_socat()

--- a/test/functional/test_cli_commands.py
+++ b/test/functional/test_cli_commands.py
@@ -265,6 +265,22 @@ class test_node_cli(unittest.TestCase):
 
         assert "Node {} runtime workspace doesn't exist".format(self.node_name) in output_info['destroy'][1]
 
+    def test_init(self):
+        """
+        CLI test: test init "-f" which will remove existing workspace
+        """
+        output_info = {}
+        output_start = run_command("infrasim node start")
+        self.assertEqual(output_start[0], 0)
+        self.assertTrue(Workspace.check_workspace_exists(self.node_name))
+        output_info['start'] = run_command("infrasim node info")
+        self.assertEqual(output_info['start'][0], 0)
+
+        output_init = run_command("infrasim init -s")
+        self.assertEqual(output_init[0], 0)
+
+        output_init_force = run_command("infrasim init -s -f")
+        self.assertEqual(output_init_force[0], 0)
 
 class test_config_cli_with_runtime_node(unittest.TestCase):
     test_name = "test"

--- a/test/functional/test_cli_commands.py
+++ b/test/functional/test_cli_commands.py
@@ -281,6 +281,7 @@ class test_node_cli(unittest.TestCase):
 
         output_init_force = run_command("infrasim init -s -f")
         self.assertEqual(output_init_force[0], 0)
+        self.assertTrue(config.infrasim_home)
 
 class test_config_cli_with_runtime_node(unittest.TestCase):
     test_name = "test"


### PR DESCRIPTION
Add '-f' parameter for "Infrasim init"
If there is node workspace existing, "init" action will be broken without '-f' parameter.
With '-f' parameter, the node will be destroy first, then init action.