### PR TITLE
Bugfix: param parsing in boot_param

### DIFF
--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1535,12 +1535,12 @@ class CCompute(Task, CElement):
             if os.path.exists(bootdev_path) is True:
                 with open(bootdev_path, "r") as f:
                     boot_param = f.readlines()
-                boot_param = boot_param[0].strip()
-                if boot_param == "default":
+                boot_param[0] = boot_param[0].strip()
+                if boot_param[0] == "default":
                     self.__boot_order = "c"
-                elif boot_param == "pxe":
+                elif boot_param[0] == "pxe":
                     self.__boot_order = "n"
-                elif boot_param == "cdrom":
+                elif boot_param[0] == "cdrom":
                     self.__boot_order = "d"
                 else:
                     self.__boot_order = "ncd"


### PR DESCRIPTION
boot_param is set to be a list but later assigned a str, which result in
failure when calling append.
caught by CI T97939.

Error reproduce:
```
sudo infrasim node start
ipmitool -U admin -P admin -H <bmc intf> chassis bootdev disk
ipmitool -U admin -P admin -H <bmc intf> chassis power reset
```
You can see qemu is dead.
Try to restart service by
`sudo infrasim node restart` would fail, see openipmi log:
``` 
File "/usr/local/lib/python2.7/dist-packages/infrasim/model.py", line 1547, in handle_parms
    boot_param.append("order={}".format(self.__boot_order))
AttributeError: 'str' object has no attribute 'append'
```
