### PR TITLE
Donnot set default value for l2-cache-size and refcount-cache-size.

### DIFF
--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -544,8 +544,8 @@ class CBaseDrive(CElement):
         self._lun = 0
 
         self.__l2_cache_size = None  # unit: byte
-        self.__refcount_cache_size = None # unit: byte
-        self.__cluster_size = 128 # unit: KB
+        self.__refcount_cache_size = None  # unit: byte
+        self.__cluster_size = 128  # unit: KB
 
     @property
     def index(self):
@@ -574,10 +574,10 @@ class CBaseDrive(CElement):
         self.__aio = self._drive_info.get("aio")
         self.__size = self._drive_info.get("size", 8)
         self.__drive_file = self._drive_info.get("file")
-        self.__wwn = self._drive_info.get("wwn");
+        self.__wwn = self._drive_info.get("wwn")
 
-        self.__l2_cache_size = self._drive_info.get("l2-cache-size", 64 * 1024 * 1024)
-        self.__refcount_cache_size = self._drive_info.get("refcount-cache-size", 64 * 1024 * 1024)
+        self.__l2_cache_size = self._drive_info.get("l2-cache-size")
+        self.__refcount_cache_size = self._drive_info.get("refcount-cache-size")
 
         # assume the files starts with "/dev/" are block device
         # all the block devices are assumed to be raw format
@@ -603,7 +603,8 @@ class CBaseDrive(CElement):
 
         if not os.path.exists(self.__drive_file):
             logger.info("Creating drive: {}".format(self.__drive_file))
-            command = "qemu-img create -f qcow2 -o cluster_size={0}K {1} {2}G".format(self.__cluster_size, self.__drive_file, self.__size)
+            command = "qemu-img create -f {0} -o cluster_size={1}K {2} {3}G".format(self.__format, self.__cluster_size,
+                                                                                    self.__drive_file, self.__size)
             try:
                 run_command(command)
             except CommandRunFailed as e:
@@ -1700,8 +1701,8 @@ class CBMC(Task):
         if self.__lan_interface not in helper.get_all_interfaces():
             print "Specified BMC interface {} doesn\'t exist, but BMC will still start."\
                 .format(self.__lan_interface)
-            logger.warning("Specified BMC interface {} doesn\'t exist.".
-                                 format(self.__lan_interface))
+            logger.warning("Specified BMC interface {} doesn\'t exist.".format(
+                self.__lan_interface))
 
         # check if lan interface has IP address
         elif not self.__ipmi_listen_range:
@@ -1984,7 +1985,7 @@ class CSocat(Task):
     def terminate(self):
         super(CSocat, self).terminate()
         if os.path.exists(self.__socket_serial):
-            os.remove(self.__socket_serial);
+            os.remove(self.__socket_serial)
 
     def get_commandline(self):
         socat_str = "{0} pty,link={1},waitslave " \
@@ -2278,7 +2279,7 @@ class NumaCtl(object):
             else:
                 self._core_map_avai[key].append(True)
 
-        self.__class__.HT_FACTOR = len(self._core_map[(0,0)])
+        self.__class__.HT_FACTOR = len(self._core_map[(0, 0)])
 
     def get_cpu_list(self, num):
         processor_use_up = True
@@ -2290,16 +2291,16 @@ class NumaCtl(object):
         for socket in self._socket_list:
             count_avai = 0
             for core in self._core_list:
-                for avai in self._core_map_avai[(socket,core)]:
+                for avai in self._core_map_avai[(socket, core)]:
                     if avai:
-                        count_avai +=1
+                        count_avai += 1
             if count_avai < num:
                 continue
             else:
                 socket_to_use = socket
                 processor_use_up = False
                 break
-        if processor_use_up or socket_to_use<0:
+        if processor_use_up or socket_to_use < 0:
             raise Exception("All sockets don't have enough processor to bind.")
 
         # Append core which all HT processor are available
@@ -2307,7 +2308,7 @@ class NumaCtl(object):
             if num - assigned_count >= self.HT_FACTOR:
                 # check if all processor are available on this core
                 all_avai = reduce(lambda x, y: x and y,
-                            self._core_map_avai[(socket_to_use, core)])
+                                  self._core_map_avai[(socket_to_use, core)])
                 if all_avai:
                     cpu_list += self._core_map[(socket_to_use, core)]
                     self._core_map_avai[(socket_to_use, core)] = [False] * self.HT_FACTOR
@@ -2321,7 +2322,7 @@ class NumaCtl(object):
         for core in self._core_list:
             # check availability of processors on this core
             core_avai_list = self._core_map_avai[(socket_to_use, core)]
-            core_avai_count = len(filter(lambda x:x, core_avai_list))
+            core_avai_count = len(filter(lambda x: x, core_avai_list))
 
             if num - assigned_count <= core_avai_count:
                 # assign
@@ -2333,7 +2334,6 @@ class NumaCtl(object):
                         if num == assigned_count:
                             return cpu_list
 
-
     def print_core_map(self):
         print "============================================================"
         print "Core and Socket Information (as reported by '/proc/cpuinfo')"
@@ -2344,7 +2344,7 @@ class NumaCtl(object):
 
         max_processor_len = len(str(len(self._core_list) * len(self._socket_list) * self.HT_FACTOR - 1))
         max_core_map_len = max_processor_len * self.HT_FACTOR \
-                            + len('[, ]') + len('Socket ')
+            + len('[, ]') + len('Socket ')
         max_core_id_len = len(str(max(self._core_list)))
 
         print " ".ljust(max_core_id_len + len('Core ')),
@@ -2359,5 +2359,5 @@ class NumaCtl(object):
         for c in self._core_list:
             print "Core %s" % str(c).ljust(max_core_id_len),
             for s in self._socket_list:
-                print str(self._core_map[(s,c)]).ljust(max_core_map_len),
+                print str(self._core_map[(s, c)]).ljust(max_core_map_len),
             print "\n"

--- a/test/functional/test_cli_commands.py
+++ b/test/functional/test_cli_commands.py
@@ -287,6 +287,7 @@ class test_node_cli(unittest.TestCase):
         self.assertEqual(output_init_force[0], 0)
         self.assertTrue(config.infrasim_home)
 
+
 class test_config_cli_with_runtime_node(unittest.TestCase):
     test_name = "test"
     test_workspace = os.path.join(config.infrasim_home, test_name)
@@ -486,7 +487,7 @@ class test_global_status(unittest.TestCase):
 
     def test_nodes_global_status_start_stop_destroy(self):
 
-        output_status={}
+        output_status = {}
         output_status["start1"] = run_command("infrasim global status")[1]
         words = ['name', 'bmc', 'node', 'socat', 'ports', 'test1']
         for word in words:

--- a/test/functional/test_configuration_change.py
+++ b/test/functional/test_configuration_change.py
@@ -12,7 +12,6 @@ import subprocess
 import os
 import yaml
 import time
-import hashlib
 import paramiko
 from infrasim import model
 from infrasim import helper
@@ -50,11 +49,13 @@ def read_buffer(channel):
         time.sleep(1)
     return str_output
 
+
 def get_qemu_pid(node):
     for t in node.get_task_list():
         if isinstance(t, model.CCompute):
             return t.get_task_pid()
     return None
+
 
 class test_compute_configuration_change(unittest.TestCase):
 
@@ -150,7 +151,6 @@ class test_compute_configuration_change(unittest.TestCase):
         except InfraSimError, e:
             print e.value
             assert False
-
 
         self.conf["compute"]["storage_backend"] = [{
             "type": "ahci",

--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -22,9 +22,8 @@ import yaml
 import shutil
 import telnetlib
 import socket
-import signal
 from test.fixtures import FakeConfig
-from nose.tools import assert_raises
+
 
 def run_command(cmd="", shell=True, stdout=None, stderr=None):
     child = subprocess.Popen(cmd, shell=shell, stdout=stdout, stderr=stderr)
@@ -390,7 +389,6 @@ class test_ipmi_console_config_change(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        ssh = paramiko.SSHClient()
         node_info = {}
         fake_config = fixtures.FakeConfig()
         node_info = fake_config.get_node_info()
@@ -461,7 +459,7 @@ class test_ipmi_console_config_change(unittest.TestCase):
         Verify vBMC console is not listening on default port 9000
         """
         try:
-            tn = telnetlib.Telnet(host="127.0.0.1", port=9000, timeout=5)
+            telnetlib.Telnet(host="127.0.0.1", port=9000, timeout=5)
         except socket.error:
             pass
         else:

--- a/test/functional/test_ipmi_kcs_smbios.py
+++ b/test/functional/test_ipmi_kcs_smbios.py
@@ -7,7 +7,6 @@ import unittest
 import os
 import time
 import yaml
-import hashlib
 from infrasim import model
 from infrasim import helper
 from infrasim import InfraSimError

--- a/test/functional/test_main_intf.py
+++ b/test/functional/test_main_intf.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 '''
 *********************************************************
 Copyright @ 2015 EMC Corporation All Rights Reserved
@@ -6,17 +5,16 @@ Copyright @ 2015 EMC Corporation All Rights Reserved
 '''
 # -*- coding: utf-8 -*-
 
+import subprocess
+import unittest
+from infrasim import run_command
+from infrasim import helper
+
+
 """
 Test infrasim-main start command to check the output
 matches the correct format
 """
-
-import subprocess
-import unittest
-import re
-
-from infrasim import run_command
-from infrasim import helper
 
 
 class test_start_intf(unittest.TestCase):
@@ -29,7 +27,6 @@ class test_start_intf(unittest.TestCase):
         pass
 
     def test_ip4addr_list(self):
-        ip_list = []
 
         try:
             test_ip_list = helper.ip4_addresses()

--- a/test/functional/test_node_ports.py
+++ b/test/functional/test_node_ports.py
@@ -8,7 +8,6 @@ from infrasim import model
 from infrasim import ArgsNotCorrect, run_command
 import threading
 from infrasim import ipmiconsole
-from infrasim.ipmiconsole.common import IpmiError
 
 PS_QEMU = "ps ax | grep qemu"
 PS_IPMI = "ps ax | grep ipmi"
@@ -16,6 +15,7 @@ PS_SOCAT = "ps ax | grep socat"
 PS_RACADM = "ps ax | grep racadmsim"
 old_path = os.environ.get("PATH")
 new_path = "{}/bin:{}".format(os.environ.get("PYTHONPATH"), old_path)
+
 
 class test_node_ports(unittest.TestCase):
 
@@ -59,7 +59,6 @@ class test_node_ports(unittest.TestCase):
                 break
 
     def test_start_node1_then_start_node2(self):
-        old_name = self.node_info['name']
         self.node_info['name'] = "test1"
         node1 = model.CNode(self.node_info)
         node1.init()
@@ -224,7 +223,7 @@ class test_start_node_with_conflict_port(unittest.TestCase):
         if 'dell' in self.node_info_2['type']:
             self.node_info_2['racadm'] = {}
             self.node_info_2['racadm']['port'] = 10023
-        #self.node_info_2['bmc_connection_port'] = 9101
+        # self.node_info_2['bmc_connection_port'] = 9101
         self.node_info_2['compute']['vnc_display'] = 2
         self.node_info_2['compute']['monitor'] = {
             'mode': 'readline',
@@ -273,7 +272,7 @@ class test_start_node_with_conflict_port(unittest.TestCase):
         self.node_info_2['ipmi_console_ssh'] = 9301
         self.node_info_2['ipmi_console_port'] = 9001
         self.node_info_2['bmc_connection_port'] = 9101
-        #self.node_info_2['compute']['vnc_display'] = 2
+        # self.node_info_2['compute']['vnc_display'] = 2
         self.node_info_2['compute']['monitor'] = {
             'mode': 'readline',
             'chardev': {
@@ -408,7 +407,6 @@ class test_start_node_with_conflict_port(unittest.TestCase):
         if 'dell' in self.node_info['type']:
             assert "test1" in racadm_result
 
-
         ipmi_console_thread = threading.Thread(target=ipmiconsole.start, args=(self.node_info["name"],))
         ipmi_console_thread.setDaemon(True)
         ipmi_console_thread.start()
@@ -443,6 +441,5 @@ class test_start_node_with_conflict_port(unittest.TestCase):
         assert "ssh port 9300 is already in use." in ipmi_console_result
 
         ipmiconsole.stop(self.node_info["name"])
-
         node2.stop()
         node2.terminate_workspace()

--- a/test/functional/test_serial.py
+++ b/test/functional/test_serial.py
@@ -25,6 +25,7 @@ Test serial functions:
 
 class test_serial(unittest.TestCase):
     TMP_CONF_FILE = "/tmp/test.yml"
+
     @classmethod
     def setUpClass(cls):
         socat.stop_socat()

--- a/test/functional/test_start_stop.py
+++ b/test/functional/test_start_stop.py
@@ -151,7 +151,6 @@ def check_node_stop_workspace(node_name):
     assert os.path.exists(node_qemu) is False
 
 
-
 class test_control_by_lib(unittest.TestCase):
 
     @classmethod
@@ -159,9 +158,9 @@ class test_control_by_lib(unittest.TestCase):
         fake_config = fixtures.FakeConfig()
         cls.conf = fake_config.get_node_info()
         cls.node_root = os.path.join(config.infrasim_home, cls.conf["name"])
-        
+
         # Add several strage controllers and drives to node config file.
-	drives = []
+        drives = []
         drives.append({'size': 8, 'file': "{}/sdb.img".format(cls.node_root)})
         drives.append({'size': 8, 'file': "{}/sdc.img".format(cls.node_root)})
         drives.append({'size': 8, 'file': "{}/sdd.img".format(cls.node_root)})
@@ -189,7 +188,7 @@ class test_control_by_lib(unittest.TestCase):
             yaml.dump(cls.conf, outfile, default_flow_style=False)
 
         os.system("infrasim config add test /tmp/test.yml")
-        
+
     @classmethod
     def tearDownClass(cls):
         node = model.CNode(cls.conf)
@@ -254,8 +253,8 @@ class test_control_by_cli(unittest.TestCase):
 
     fake_config = fixtures.FakeConfig()
     test_config = fake_config.get_node_info()
-    image_path =  "{}/{}".format(config.infrasim_home, node_name)
-    
+    image_path = "{}/{}".format(config.infrasim_home, node_name)
+
     # Add several storage controllers/drives in node config file.
     drives = []
     drives.append({'size': 8, 'file': "{}/sdb.img".format(image_path)})
@@ -285,8 +284,6 @@ class test_control_by_cli(unittest.TestCase):
         yaml.dump(test_config, outfile, default_flow_style=False)
 
     os.system("infrasim config add test /tmp/test.yml")
-
-
 
     def tearDown(self):
         os.system("infrasim node destroy {}".format(self.node_name))

--- a/test/functional/test_storage.py
+++ b/test/functional/test_storage.py
@@ -49,11 +49,13 @@ drive6 = [{"size": 8, "file": "/tmp/sda.img"},
           {"size": 8, "file": "/tmp/sde.img"},
           {"size": 16, "file": "/tmp/sdf.img"}]
 
+
 def get_qemu_pid(node):
     for t in node.get_task_list():
         if isinstance(t, model.CCompute):
             return t.get_task_pid()
     return None
+
 
 class test_ahci_controller_with_two_drives(unittest.TestCase):
 
@@ -101,6 +103,7 @@ class test_ahci_controller_with_two_drives(unittest.TestCase):
         assert "/tmp/sdb.img" in qemu_cmdline
         assert "format=qcow2" in qemu_cmdline
 
+
 class test_megasas_controller_with_two_drives(unittest.TestCase):
 
     @classmethod
@@ -146,6 +149,7 @@ class test_megasas_controller_with_two_drives(unittest.TestCase):
         assert "/tmp/sda.img" in qemu_cmdline
         assert "/tmp/sdb.img" in qemu_cmdline
         assert "format=qcow2" in qemu_cmdline
+
 
 class test_lsi_controller_with_two_drives(unittest.TestCase):
 
@@ -198,12 +202,12 @@ class test_lsi_controller_with_two_drives(unittest.TestCase):
 class test_ahci_controller_with_more_than_six_drives(unittest.TestCase):
 
     drives7 = [{"size": 8, "file": "/tmp/sda.img"},
-          {"size": 16, "file": "/tmp/sdb.img"},
-          {"size": 8, "file": "/tmp/sdc.img"},
-          {"size": 16, "file": "/tmp/sdd.img"},
-          {"size": 8, "file": "/tmp/sde.img"},
-          {"size": 16, "file": "/tmp/sdf.img"},
-          {"size": 8, "file": "/tmp/sdg.img"}]
+               {"size": 16, "file": "/tmp/sdb.img"},
+               {"size": 8, "file": "/tmp/sdc.img"},
+               {"size": 16, "file": "/tmp/sdd.img"},
+               {"size": 8, "file": "/tmp/sde.img"},
+               {"size": 16, "file": "/tmp/sdf.img"},
+               {"size": 8, "file": "/tmp/sdg.img"}]
 
     @classmethod
     def setUp(cls):
@@ -238,7 +242,7 @@ class test_ahci_controller_with_more_than_six_drives(unittest.TestCase):
         node.start()
 
         controller_type_ahci = run_command("infrasim node info {} | grep -c ahci".
-                                      format(self.conf["name"]))
+                                           format(self.conf["name"]))
         self.assertEqual(int(controller_type_ahci[1]), 2)
 
         qemu_pid = get_qemu_pid(node)
@@ -310,7 +314,7 @@ class test_ahci_controller_with_more_than_six_drives(unittest.TestCase):
         node.start()
 
         controller_type_ahci = run_command("infrasim node info {} | grep -c ahci".
-                                      format(self.conf["name"]))
+                                           format(self.conf["name"]))
         self.assertEqual(int(controller_type_ahci[1]), 4)
 
         qemu_pid = get_qemu_pid(node)
@@ -338,7 +342,6 @@ class test_ahci_controller_with_more_than_six_drives(unittest.TestCase):
         assert "drive=sata1-0-0-0" in qemu_cmdline
         assert "drive=sata2-0-1-0" in qemu_cmdline
         assert "drive=sata3-0-2-0" in qemu_cmdline
-
 
 
 class test_ahci_controller_with_six_drives(unittest.TestCase):
@@ -391,6 +394,7 @@ class test_ahci_controller_with_six_drives(unittest.TestCase):
         assert "/tmp/sdf.img" in qemu_cmdline
         assert "format=qcow2" in qemu_cmdline
 
+
 class test_megasas_controller_with_six_drives(unittest.TestCase):
 
     @classmethod
@@ -441,6 +445,7 @@ class test_megasas_controller_with_six_drives(unittest.TestCase):
         assert "/tmp/sdf.img" in qemu_cmdline
         assert "format=qcow2" in qemu_cmdline
 
+
 class test_lsi_controller_with_six_drives(unittest.TestCase):
 
     @classmethod
@@ -490,6 +495,7 @@ class test_lsi_controller_with_six_drives(unittest.TestCase):
         assert "/tmp/sde.img" in qemu_cmdline
         assert "/tmp/sdf.img" in qemu_cmdline
         assert "format=qcow2" in qemu_cmdline
+
 
 class test_three_storage_controllers(unittest.TestCase):
 
@@ -604,6 +610,7 @@ class test_three_storage_controllers(unittest.TestCase):
         assert "{}/sdq.img".format(image_path) in qemu_cmdline
         assert "{}/sdr.img".format(image_path) in qemu_cmdline
         assert "format=qcow2" in qemu_cmdline
+
 
 class test_four_storage_controllers(unittest.TestCase):
 
@@ -741,6 +748,7 @@ class test_four_storage_controllers(unittest.TestCase):
         assert "{}/sdx.img".format(image_path) in qemu_cmdline
         assert "format=qcow2" in qemu_cmdline
 
+
 class test_qemu_boot_from_disk_img_at_1st_controller(unittest.TestCase):
 
     @classmethod
@@ -837,8 +845,8 @@ class test_qemu_boot_from_disk_img_at_1st_controller(unittest.TestCase):
 
         assert True
 
-class test_qemu_boot_from_disk_img_at_2nd_controller(unittest.TestCase):
 
+class test_qemu_boot_from_disk_img_at_2nd_controller(unittest.TestCase):
 
     @classmethod
     def setUp(self):
@@ -933,8 +941,8 @@ class test_qemu_boot_from_disk_img_at_2nd_controller(unittest.TestCase):
 
         assert True
 
-class test_qemu_boot_from_disk_img_at_3rd_controller(unittest.TestCase):
 
+class test_qemu_boot_from_disk_img_at_3rd_controller(unittest.TestCase):
 
     @classmethod
     def setUp(self):

--- a/test/functional/test_version_command.py
+++ b/test/functional/test_version_command.py
@@ -6,16 +6,15 @@ Copyright @ 2015 EMC Corporation All Rights Reserved
 '''
 # -*- coding: utf-8 -*-
 
+import unittest
+import re
+from infrasim import version
+
+
 """
 Test version command to check the output
 matches the correct format
 """
-
-import unittest
-import re
-
-from infrasim import run_command
-from infrasim import version
 
 
 class test_version_command(unittest.TestCase):

--- a/test/functional/test_with_bridge.py
+++ b/test/functional/test_with_bridge.py
@@ -282,7 +282,7 @@ class test_bmc_interface_with_bridge(unittest.TestCase):
         node.start()
 
         self.set_port_forward()
-        self.verify_qemu_local_lan({"IP Address": "0.0.0.0", "MAC Address":"00:00:00:00:00:00"})
+        self.verify_qemu_local_lan({"IP Address": "0.0.0.0", "MAC Address": "00:00:00:00:00:00"})
 
     def test_bmc_intf_exists_no_ip(self):
         """


### PR DESCRIPTION
1. Donot set default value for l2-cache-size and refcount-cache-size,  since 
   not all of images support the attributes
2. Make pylint happy.