### PR TITLE
Bugfix: global status randomly fails

### DIFF
--- a/infrasim/helper.py
+++ b/infrasim/helper.py
@@ -4,6 +4,7 @@ Copyright @ 2015 EMC Corporation All Rights Reserved
 *********************************************************
 '''
 import os
+import time
 import socket
 import multiprocessing
 from functools import wraps
@@ -318,3 +319,15 @@ def double_fork(func):
         os._exit(os.EX_OK)
 
     return wrapper
+
+
+def try_func(times, func, *args, **kwargs):
+    for i in range(times):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            time.sleep(0.5)
+            continue
+    raise Exception(
+        "Tried {} times already, but still failed to run {}".format(
+            times, func))

--- a/test/functional/test_cli_commands.py
+++ b/test/functional/test_cli_commands.py
@@ -10,13 +10,13 @@ import os
 import unittest
 import yaml
 import re
+import time
 import infrasim.config as config
 from infrasim import run_command
 from test.fixtures import FakeConfig
 import infrasim.model as model
 from infrasim.workspace import Workspace
 from test import fixtures
-import time
 
 
 old_path = os.environ.get("PATH")
@@ -554,4 +554,5 @@ class test_global_status(unittest.TestCase):
 
         node2.terminate_workspace()
         output_status["destroy"] = run_command("infrasim global status")[1]
-        assert "There is no node." in output_status["destroy"]
+        assert ("test1" not in output_status["destroy"]) and (
+            "test2" not in output_status["destroy"])

--- a/test/functional/test_configuration_change.py
+++ b/test/functional/test_configuration_change.py
@@ -167,7 +167,6 @@ class test_compute_configuration_change(unittest.TestCase):
 
         import telnetlib
         import paramiko
-        import time
         tn = telnetlib.Telnet(host="127.0.0.1", port=2345)
         tn.read_until("(qemu)")
         tn.write("hostfwd_add ::2222-:22\n")
@@ -177,20 +176,10 @@ class test_compute_configuration_change(unittest.TestCase):
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         paramiko.util.log_to_file("filename.log")
-        while True:
-            try:
-                ssh.connect("127.0.0.1", port=2222, username="cirros",
-                            password="cubswin:)", timeout=120)
-                ssh.close()
-                break
-            except paramiko.SSHException:
-                time.sleep(1)
-                continue
-            except Exception:
-                assert False
-                return
-
-        assert True
+        helper.try_func(600, paramiko.SSHClient.connect, ssh,
+                        "127.0.0.1", port=2222, username="cirros",
+                        password="cubswin:)", timeout=120)
+        ssh.close()
 
 
 class test_bmc_configuration_change(unittest.TestCase):

--- a/test/functional/test_ipmi_kcs_smbios.py
+++ b/test/functional/test_ipmi_kcs_smbios.py
@@ -45,7 +45,6 @@ tmp_conf_file = "/tmp/test.yml"
 old_path = os.environ.get("PATH")
 new_path = "{}/bin:{}".format(os.environ.get("PYTHONPATH"), old_path)
 
-
 def setup_module():
     test_img_file = "/tmp/kcs.img"
     DOWNLOAD_URL = "https://github.com/InfraSIM/test/raw/master/image/kcs.img"
@@ -60,6 +59,9 @@ def setup_module():
 
 
 def teardown_module():
+    global conf
+    if conf:
+        stop_node()
     os.environ["PATH"] = old_path
 
 
@@ -95,18 +97,9 @@ def start_node(node_type):
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     paramiko.util.log_to_file("filename.log")
-    while True:
-        try:
-            ssh.connect("127.0.0.1", port=2222, username="root",
-                        password="root", timeout=120)
-            ssh.close()
-            break
-        except paramiko.SSHException:
-            time.sleep(1)
-            continue
-        except Exception:
-            assert False
-
+    helper.try_func(600, paramiko.SSHClient.connect, ssh, "127.0.0.1",
+                    port=2222, username="root", password="root", timeout=120)
+    ssh.close()
     time.sleep(5)
 
 

--- a/test/functional/test_storage.py
+++ b/test/functional/test_storage.py
@@ -749,6 +749,27 @@ class test_four_storage_controllers(unittest.TestCase):
         assert "format=qcow2" in qemu_cmdline
 
 
+def set_port_forward_try_ssh():
+    import time
+    import paramiko
+    time.sleep(3)
+    import telnetlib
+    tn = telnetlib.Telnet(host="127.0.0.1", port=2345)
+    tn.read_until("(qemu)")
+    tn.write("hostfwd_add ::2222-:22\n")
+    tn.read_until("(qemu)")
+    tn.close()
+
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    paramiko.util.log_to_file("filename.log")
+    helper.try_func(600, paramiko.SSHClient.connect, ssh,
+                    "127.0.0.1", port=2222, username="cirros",
+                    password="cubswin:)", timeout=120)
+    ssh.close()
+    time.sleep(5)
+
+
 class test_qemu_boot_from_disk_img_at_1st_controller(unittest.TestCase):
 
     @classmethod
@@ -818,32 +839,7 @@ class test_qemu_boot_from_disk_img_at_1st_controller(unittest.TestCase):
         node.precheck()
         node.start()
 
-        import telnetlib
-        import paramiko
-        import time
-        tn = telnetlib.Telnet(host="127.0.0.1", port=2345)
-        tn.read_until("(qemu)")
-        tn.write("hostfwd_add ::2222-:22\n")
-        tn.read_until("(qemu)")
-        tn.close()
-
-        ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        paramiko.util.log_to_file("filename.log")
-        while True:
-            try:
-                ssh.connect("127.0.0.1", port=2222, username="cirros",
-                            password="cubswin:)", timeout=120)
-                ssh.close()
-                break
-            except paramiko.SSHException:
-                time.sleep(1)
-                continue
-            except Exception:
-                assert False
-                return
-
-        assert True
+        set_port_forward_try_ssh()
 
 
 class test_qemu_boot_from_disk_img_at_2nd_controller(unittest.TestCase):
@@ -914,32 +910,7 @@ class test_qemu_boot_from_disk_img_at_2nd_controller(unittest.TestCase):
         node.precheck()
         node.start()
 
-        import telnetlib
-        import paramiko
-        import time
-        tn = telnetlib.Telnet(host="127.0.0.1", port=2345)
-        tn.read_until("(qemu)")
-        tn.write("hostfwd_add ::2222-:22\n")
-        tn.read_until("(qemu)")
-        tn.close()
-
-        ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        paramiko.util.log_to_file("filename.log")
-        while True:
-            try:
-                ssh.connect("127.0.0.1", port=2222, username="cirros",
-                            password="cubswin:)", timeout=120)
-                ssh.close()
-                break
-            except paramiko.SSHException:
-                time.sleep(1)
-                continue
-            except Exception:
-                assert False
-                return
-
-        assert True
+        set_port_forward_try_ssh()
 
 
 class test_qemu_boot_from_disk_img_at_3rd_controller(unittest.TestCase):
@@ -1004,28 +975,4 @@ class test_qemu_boot_from_disk_img_at_3rd_controller(unittest.TestCase):
         node.init()
         node.precheck()
         node.start()
-        import telnetlib
-        import paramiko
-        import time
-        tn = telnetlib.Telnet(host="127.0.0.1", port=2345)
-        tn.read_until("(qemu)")
-        tn.write("hostfwd_add ::2222-:22\n")
-        tn.read_until("(qemu)")
-        tn.close()
-        ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        paramiko.util.log_to_file("filename.log")
-        while True:
-            try:
-                ssh.connect("127.0.0.1", port=2222, username="cirros",
-                            password="cubswin:)", timeout=120)
-                ssh.close()
-                break
-            except paramiko.SSHException:
-                time.sleep(1)
-                continue
-            except Exception:
-                assert False
-                return
-
-        assert True
+        set_port_forward_try_ssh()

--- a/test/functional/test_with_bridge.py
+++ b/test/functional/test_with_bridge.py
@@ -239,17 +239,10 @@ class test_bmc_interface_with_bridge(unittest.TestCase):
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         paramiko.util.log_to_file("filename.log")
-        while True:
-            try:
-                ssh.connect("127.0.0.1", port=2222, username="root",
-                            password="root", timeout=120)
-                ssh.close()
-                break
-            except paramiko.SSHException:
-                time.sleep(1)
-                continue
-            except Exception:
-                assert False
+        helper.try_func(600, paramiko.SSHClient.connect, ssh,
+                        "127.0.0.1", port=2222, username="root",
+                        password="root", timeout=120)
+        ssh.close()
 
         time.sleep(5)
 


### PR DESCRIPTION
In global status command, port occupation will be checked under each
process, however some of them are not ready to listen when the services
just start.

In this case, we have to poll to check when the ports start to listen.
It's not a good way to write a loop everywhere this kind of polling is
used, so we decide to define a try_func function to reduce redundancy.

def try_func(times, func, *args, **kwargs)
"""
times: maximum trials to call the function
func: the function to call
*args: no keyword bounded arguments
**kwargs: keyword bounded arguments
return: function return value or None
"""

If it still fails after *times* calls, this method will raise an
Exception.