### PR TITLE
Add device ID for drive device

### DIFF
--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -678,6 +678,8 @@ class CBaseDrive(CElement):
         self._dev_attrs["drive"] = "{}{}-{}-{}-{}".format(self.prefix, self.__bus,
                                                           self._channel, self._scsi_id, self._lun)
 
+        self._dev_attrs["id"] = "dev-{}".format(self._dev_attrs["drive"])
+
 
 class SCSIDrive(CBaseDrive):
     def __init__(self, drive_info):


### PR DESCRIPTION
When qemu call device_del, it needs a device ID.