### PR TITLE
add hint msg after edit node config file when node workspace exits

### DIFF
--- a/infrasim/cli.py
+++ b/infrasim/cli.py
@@ -81,6 +81,12 @@ class ConfigCommands(object):
                                    "{}.yml".format(node_name))
         try:
             os.system("{} {}".format(editor, config_path))
+            if Workspace.check_workspace_exists(node_name):
+                print "Warning: " \
+                      "\033[93mPlease destroy node {}\033[0m " \
+                      "before start or restart, " \
+                      "or this edit won't work." .format(node_name)
+
         except OSError, e:
             print e
 


### PR DESCRIPTION
if  a user edits the node config file and this node workspace exits,  warn user to destroy node, then this edit will work.