### PR TITLE
Refine CMonitor

### DIFF
--- a/infrasim/helper.py
+++ b/infrasim/helper.py
@@ -10,6 +10,7 @@ import hashlib
 import re
 import socket
 import multiprocessing
+import types
 from functools import wraps
 from ctypes import cdll
 from socket import AF_INET, AF_INET6, inet_ntop
@@ -345,4 +346,33 @@ def literal_string(s):
         if len(s) == len(t):
             return any_backspaces.sub("", t)
         s = t
- 
+
+def is_valid_ip(ip):
+    '''
+    [Function]: This function is to judge if ip is a valid IP, in str or int list
+    [Input   ]: ip - the IP to judge, should be string or list
+    [Output  ]: True - ip is valid
+                False - ip is not valid
+    '''
+
+    if type(ip) in [types.StringType, types.UnicodeType]:
+        p = re.search('^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$', ip)
+        if p:
+            for i in range(1,5):
+                if int(p.group(i),0) not in range(0,256):
+                    return False
+            return True
+        else:
+            return False
+    elif type(ip) is types.ListType:
+        if len(ip) != 4:
+            return False
+        else:
+            for i in range(4):
+                if type(ip[i]) is not types.IntType:
+                    return False
+                elif ip[i] not in range(0,256):
+                    return False
+            return True
+    else:
+        return False

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -1220,7 +1220,7 @@ class CMonitor(CElement):
         self.__workspace = ws
 
     def precheck(self):
-        if not self.__mode in ["readline", "control"]:
+        if self.__mode not in ["readline", "control"]:
             self.logger.exception("[Monitor] Invalid monitor mode: {}".format(self.__mode))
             raise ArgsNotCorrect("Invalid monitor mode: {}".format(self.__mode))
 
@@ -1254,25 +1254,25 @@ class CMonitor(CElement):
         chardev_info = {}
         if self.__mode == "readline":
             chardev_info = self.__monitor.get("chardev", {})
-            if not "backend" in chardev_info:
+            if "backend" not in chardev_info:
                 chardev_info["backend"] = "socket"
-            if not "server" in chardev_info:
+            if "server" not in chardev_info:
                 chardev_info["server"] = True
-            if not "wait" in chardev_info:
+            if "wait" not in chardev_info:
                 chardev_info["wait"] = False
-            if not "host" in chardev_info:
+            if "host" not in chardev_info:
                 chardev_info["host"] = "127.0.0.1"
-            if not "port" in chardev_info:
+            if "port" not in chardev_info:
                 chardev_info["port"] = 2345
         elif self.__mode == "control":
             chardev_info = self.__monitor.get("chardev", {})
-            if not "backend" in chardev_info:
+            if "backend" not in chardev_info:
                 chardev_info["backend"] = "socket"
-            if not "server" in chardev_info:
+            if "server" not in chardev_info:
                 chardev_info["server"] = True
-            if not "wait" in chardev_info:
+            if "wait" not in chardev_info:
                 chardev_info["wait"] = False
-            if not "path" in chardev_info:
+            if "path" not in chardev_info:
                 if self.get_workspace():
                     chardev_path = os.path.join(self.get_workspace(), ".monitor")
                 else:

--- a/infrasim/racadmsim/model.py
+++ b/infrasim/racadmsim/model.py
@@ -37,28 +37,28 @@ def get_drive_topology():
     for controller_idx, controller in enumerate(node_info["compute"]["storage_backend"][1:]):
         scsi_drives = controller["drives"]
         # FIXME: index drive slots
-        curr_hdd_slot = 0
-        curr_ssd_slot = 12
-        for the_drive in scsi_drives:
-            # HDD
-            if the_drive.get("rotation", 7200) > 1:
-                drive_slot = the_drive.get("slot", curr_hdd_slot)
-                if drive_slot >= curr_hdd_slot:
-                    the_drive["slot"] = drive_slot
-                    curr_hdd_slot += 1
-                else:
-                    env.logger_r.exception("Invalid HDD slot")
-                    raise Exception("Invalid HDD slot")
-
-            # SSD
-            else:
-                drive_slot = the_drive.get("slot", curr_ssd_slot)
-                if drive_slot >= curr_ssd_slot:
-                    the_drive["slot"] = drive_slot
-                    curr_hdd_slot += 1
-                else:
-                    env.logger_r.exception("Invalid SSD slot")
-                    raise Exception("Invalid SSD slot")
+        # curr_hdd_slot = 0
+        # curr_ssd_slot = 12
+        # for the_drive in scsi_drives:
+        #     # HDD
+        #     if the_drive.get("rotation", 7200) > 1:
+        #         drive_slot = the_drive.get("slot_number", curr_hdd_slot)
+        #         if drive_slot >= curr_hdd_slot:
+        #             the_drive["slot_number"] = drive_slot
+        #             curr_hdd_slot += 1
+        #         else:
+        #             env.logger_r.exception("Invalid HDD slot")
+        #             raise Exception("Invalid HDD slot")
+        #
+        #     # SSD
+        #     else:
+        #         drive_slot = the_drive.get("slot_number", curr_ssd_slot)
+        #         if drive_slot >= curr_ssd_slot:
+        #             the_drive["slot_number"] = drive_slot
+        #             curr_hdd_slot += 1
+        #         else:
+        #             env.logger_r.exception("Invalid SSD slot")
+        #             raise Exception("Invalid SSD slot")
 
         # Map drives to certain controller index
         topo_backplane[controller_idx+1] = scsi_drives

--- a/template/racadmsim/hwinventory_storage_drive_scsi.j2
+++ b/template/racadmsim/hwinventory_storage_drive_scsi.j2
@@ -1,20 +1,20 @@
 {% import "macros.j2" as lib %}
 
 
-[InstanceID: Disk.Bay.{{ drive.slot }}:Enclosure.Internal.0-1:NonRAID.Integrated.1-{{ controller_idx }}]
+[InstanceID: Disk.Bay.{{ drive.slot_number }}:Enclosure.Internal.0-1:NonRAID.Integrated.1-{{ controller_idx }}]
 Device Type = PhysicalDisk
 LastUpdateTime = 2016-12-20T08:37:44
 LastSystemInventoryTime = 2016-12-20T08:37:44
-RemainingRatedWriteEndurance = 0%
+RemainingRatedWriteEndurance = {{ lib.get_endurance(drive, isdigit=true) }}
 OperationPercentComplete = 0%
 OperationName = None
-DriveFormFactor = 3.5 inch
+DriveFormFactor = {{ lib.get_form_factor(drive) }} inch
 PPID = {{ lib.get_part_number(drive) }}
 SASAddress = {{ lib.get_wwn(drive, prefix=false) }}
 MaxCapableSpeed = 12Gbs
 UsedSizeInBytes = 0 Bytes
 FreeSizeInBytes = 0 Bytes
-MediaType = {{ lib.get_media_type(drive) }}
+MediaType = {{ lib.get_media_type(drive, isabbr=false) }}
 BlockSizeInBytes = 512 Bytes
 T10PICapability = Not supported
 SecurityState = Unknown
@@ -29,12 +29,12 @@ ManufacturingDay = 2
 Manufacturer = {{ drive.vendor }}
 Model = {{ drive.product }}
 SizeInBytes = 4000787029504 Bytes
-Slot = {{ drive.slot }}
+Slot = {{ drive.slot_number }}
 Connector = 0
 RaidStatus = Non-RAID
 RollupStatus = OK
 PrimaryStatus = OK
-DeviceDescription = Disk {{ drive.slot }} in Backplane 1 of Integrated Storage Controller {{ controller_idx }}
-FQDD = Disk.Bay.{{ drive.slot }}:Enclosure.Internal.0-1:NonRAID.Integrated.1-{{ controller_idx }}
-InstanceID = Disk.Bay.{{ drive.slot }}:Enclosure.Internal.0-1:NonRAID.Integrated.1-{{ controller_idx }}
+DeviceDescription = Disk {{ drive.slot_number }} in Backplane 1 of Integrated Storage Controller {{ controller_idx }}
+FQDD = Disk.Bay.{{ drive.slot_number }}:Enclosure.Internal.0-1:NonRAID.Integrated.1-{{ controller_idx }}
+InstanceID = Disk.Bay.{{ drive.slot_number }}:Enclosure.Internal.0-1:NonRAID.Integrated.1-{{ controller_idx }}
 -------------------------------------------------------------------

--- a/template/racadmsim/macros.j2
+++ b/template/racadmsim/macros.j2
@@ -27,11 +27,35 @@
     {%- endif %}
 {% endmacro %}
 
-{% macro get_media_type(drive) %}
+{% macro get_media_type(drive, isabbr=true) %}
     {% if get_rotation(drive)|int < 2 -%}
-        SSD
+        {%- if isabbr -%}
+            SSD
+        {%- else -%}
+            Solid State Drive
+        {%- endif -%}
     {%- else -%}
         HDD
+    {%- endif %}
+{% endmacro %}
+
+{% macro get_form_factor(drive) %}
+    {% if get_media_type(drive) == "SSD" -%}
+        2.5
+    {%- else -%}
+        3.5
+    {%- endif %}
+{% endmacro %}
+
+{% macro get_endurance(drive, isdigit=true) %}
+    {% if get_media_type(drive) == "SSD" -%}
+        100%
+    {%- else -%}
+        {%- if isdigit -%}
+            0%
+        {%- else -%}
+            Not Applicable
+        {%- endif -%}
     {%- endif %}
 {% endmacro %}
 

--- a/template/racadmsim/storage_drive_scsi.j2
+++ b/template/racadmsim/storage_drive_scsi.j2
@@ -1,16 +1,16 @@
 {% import "macros.j2" as lib %}
 
-Disk.Bay.{{ drive.slot }}:Enclosure.Internal.0-1:NonRAID.Integrated.1-{{ controller_idx }}
+Disk.Bay.{{ drive.slot_number }}:Enclosure.Internal.0-1:NonRAID.Integrated.1-{{ controller_idx }}
    Status                           = Ok
-   DeviceDescription                = Disk {{ drive.slot }} in Backplane 1 of Integrated Storage Controller {{ controller_idx }}
+   DeviceDescription                = Disk {{ drive.slot_number }} in Backplane 1 of Integrated Storage Controller {{ controller_idx }}
    RollupStatus                     = Ok
-   Name                             = {% if lib.get_rotation(drive)|int < 2 %}Solid State Disk{% else %}Physical Disk{% endif %} 0:1:{{ drive.slot }}
+   Name                             = {% if lib.get_rotation(drive)|int < 2 %}Solid State Disk{% else %}Physical Disk{% endif %} 0:1:{{ drive.slot_number }}
    State                            = Non-Raid
    OperationState                   = Not Applicable
    PowerStatus                      = Spun-Up
    Size                             = {{ drive.size }} GB
    FailurePredicted                 = NO
-   RemainingRatedWriteEndurance     = Not Applicable
+   RemainingRatedWriteEndurance     = {{ lib.get_endurance(drive, isdigit=false) }}
    SecurityStatus                   = Not Capable
    BusProtocol                      = SAS
    MediaType                        = {{ lib.get_media_type(drive) }}
@@ -27,7 +27,7 @@ Disk.Bay.{{ drive.slot }}:Enclosure.Internal.0-1:NonRAID.Integrated.1-{{ control
    ManufacturedWeek                 = 9
    ManufacturedYear                 = 2016
    SasAddress                       = {{ lib.get_wwn(drive, prefix=true) }}
-   FormFactor                       = 3.5 Inch
+   FormFactor                       = {{ lib.get_form_factor(drive) }} Inch
    RaidNominalMediumRotationRate    = {{ lib.get_rotation(drive) }}
    T10PICapability                  = Not Capable
    BlockSizeInBytes                 = 512

--- a/test/functional/test_node_ports.py
+++ b/test/functional/test_node_ports.py
@@ -336,8 +336,7 @@ class test_start_node_with_conflict_port(unittest.TestCase):
             node2.init()
             node2.precheck()
         except ArgsNotCorrect, e:
-            assert "Monitor port 2345 is already in use." in e.value
-            assert True
+            assert "Port 2345 is already in use" in e.value
         else:
             assert False
 

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -470,6 +470,243 @@ class qemu_functions(unittest.TestCase):
         compute.handle_parms()
         assert "msg timestamp=on" in compute.get_commandline()
 
+    def test_chardev_correct_backend(self):
+        chardev_info = {
+            "backend": "socket",
+            "server": "on",
+            "wait": "off",
+            "path": "/tmp/monitor.sock"
+        }
+        chardev = model.CCharDev(chardev_info)
+        chardev.init()
+        chardev.precheck()
+        chardev.handle_parms()
+        assert "-chardev socket" in chardev.get_option()
+
+    @raises(ArgsNotCorrect)
+    def test_chardev_empty_backend(self):
+        chardev_info = {
+            "backend": "",
+            "server": "on",
+            "wait": "off",
+            "path": "/tmp/monitor.sock"
+        }
+        chardev = model.CCharDev(chardev_info)
+        chardev.init()
+        chardev.precheck()
+
+    @raises(ArgsNotCorrect)
+    def test_chardev_none_backend(self):
+        chardev_info = {
+            "server": "on",
+            "wait": "off",
+            "path": "/tmp/monitor.sock"
+        }
+        chardev = model.CCharDev(chardev_info)
+        chardev.init()
+        chardev.precheck()
+
+    def test_monitor_auto_complete_control_mode_1(self):
+        monitor_info = {
+            "mode": "control"
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        monitor.precheck()
+        monitor.handle_parms()
+        assert "-mon chardev" in monitor.get_option()
+        assert "mode=control" in monitor.get_option()
+        assert "-chardev socket" in monitor.get_option()
+        assert "server" in monitor.get_option()
+        assert "nowait" in monitor.get_option()
+        assert "path={}".format(os.path.join(config.infrasim_etc, ".monitor")) in monitor.get_option()
+
+    def test_monitor_auto_complete_control_mode_2(self):
+        monitor_info = {
+            "mode": "control",
+            "chardev": {}
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        monitor.precheck()
+        monitor.handle_parms()
+        assert "-mon chardev" in monitor.get_option()
+        assert "mode=control" in monitor.get_option()
+        assert "-chardev socket" in monitor.get_option()
+        assert "server" in monitor.get_option()
+        assert "nowait" in monitor.get_option()
+        assert "path={}".format(os.path.join(config.infrasim_etc, ".monitor")) in monitor.get_option()
+
+    def test_monitor_auto_complete_readline_mode_1(self):
+        monitor_info = {
+            "mode": "readline"
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        monitor.precheck()
+        monitor.handle_parms()
+        assert "-mon chardev" in monitor.get_option()
+        assert "mode=readline" in monitor.get_option()
+        assert "-chardev socket" in monitor.get_option()
+        assert "server" in monitor.get_option()
+        assert "nowait" in monitor.get_option()
+        assert "host=127.0.0.1" in monitor.get_option()
+        assert "port=2345" in monitor.get_option()
+
+    def test_monitor_auto_complete_readline_mode_2(self):
+        monitor_info = {
+            "mode": "readline",
+            "chardev": {}
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        monitor.precheck()
+        monitor.handle_parms()
+        assert "-mon chardev" in monitor.get_option()
+        assert "mode=readline" in monitor.get_option()
+        assert "-chardev socket" in monitor.get_option()
+        assert "server" in monitor.get_option()
+        assert "nowait" in monitor.get_option()
+        assert "host=127.0.0.1" in monitor.get_option()
+        assert "port=2345" in monitor.get_option()
+
+    def test_monitor_fault_mode(self):
+        monitor_info = {
+            "mode": "fault"
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        try:
+            monitor.precheck()
+        except ArgsNotCorrect, e:
+            assert "Invalid monitor mode: fault" in e.value
+
+    def test_monitor_fault_backend_in_control_mode(self):
+        monitor_info = {
+            "mode": "control",
+            "chardev": {
+                "backend": "file"
+            }
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        try:
+            monitor.precheck()
+        except ArgsNotCorrect, e:
+            assert "Invalid monitor chardev backend: file" in e.value
+
+    def test_monitor_fault_backend_in_readline_mode(self):
+        monitor_info = {
+            "mode": "readline",
+            "chardev": {
+                "backend": "file"
+            }
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        try:
+            monitor.precheck()
+        except ArgsNotCorrect, e:
+            assert "Invalid monitor chardev backend: file" in e.value
+
+    def test_monitor_fault_server_in_control_mode(self):
+        monitor_info = {
+            "mode": "control",
+            "chardev": {
+                "server": "ok"
+            }
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        try:
+            monitor.precheck()
+        except ArgsNotCorrect, e:
+            assert "Invalid monitor chardev server: ok" in e.value
+
+    def test_monitor_fault_server_in_readline_mode(self):
+        monitor_info = {
+            "mode": "readline",
+            "chardev": {
+                "server": "ok"
+            }
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        try:
+            monitor.precheck()
+        except ArgsNotCorrect, e:
+            assert "Invalid monitor chardev server: ok" in e.value
+
+    def test_monitor_fault_wait_in_control_mode(self):
+        monitor_info = {
+            "mode": "control",
+            "chardev": {
+                "wait": "ok"
+            }
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        try:
+            monitor.precheck()
+        except ArgsNotCorrect, e:
+            assert "Invalid monitor chardev wait: ok" in e.value
+
+    def test_monitor_fault_wait_in_readline_mode(self):
+        monitor_info = {
+            "mode": "readline",
+            "chardev": {
+                "wait": "ok"
+            }
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        try:
+            monitor.precheck()
+        except ArgsNotCorrect, e:
+            assert "Invalid monitor chardev wait: ok" in e.value
+
+    def test_monitor_fault_host_in_readline_mode(self):
+        monitor_info = {
+            "mode": "readline",
+            "chardev": {
+                "host": "localhost"
+            }
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        try:
+            monitor.precheck()
+        except ArgsNotCorrect, e:
+            assert "Invalid chardev host: localhost" in e.value
+
+    def test_monitor_fault_port_in_readline_mode(self):
+        monitor_info = {
+            "mode": "readline",
+            "chardev": {
+                "port": "someport"
+            }
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        try:
+            monitor.precheck()
+        except ArgsNotCorrect, e:
+            assert "Port is not a valid integer: someport" in e.value
+
+    def test_monitor_fault_path_in_control_mode(self):
+        monitor_info = {
+            "mode": "control",
+            "chardev": {
+                "path": "/fake/path/.monitor"
+            }
+        }
+        monitor = model.CMonitor(monitor_info)
+        monitor.init()
+        try:
+            monitor.precheck()
+        except ArgsNotCorrect, e:
+            assert "Path folder doesn't exist: /fake/path" in e.value
+
 
 class bmc_configuration(unittest.TestCase):
 


### PR DESCRIPTION
Support two monitor mode `readline` and `control`.
Do init and precheck according to monitor mode.

Added unit test for CMonitor

Signed-off-by: Echo Cheng <echo.cheng@emc.com>