### PR TITLE
Fix protocol error in serial medium

### DIFF
--- a/etc/vbmc.conf.example
+++ b/etc/vbmc.conf.example
@@ -43,7 +43,7 @@ set_working_mc 0x20
 
   # Define a serial VM inteface for channel 15 (the system interface) on
   # port 9002, just available to the local system (localhost).
-  serial 15 0.0.0.0 9002 codec VM ipmb 0x20
+  serial kcs 0.0.0.0 9002 codec VM ipmb 0x20
 
   # startcmd is what to execute to start a VM associated with the
   # codec above (localhost 9002).  It also starts a console serial port

--- a/template/vbmc.conf
+++ b/template/vbmc.conf
@@ -43,7 +43,7 @@ set_working_mc 0x20
 
   # Define a serial VM inteface for channel 15 (the system interface) on
   # port {{port_qemu_ipmi}}, just available to the local system (localhost).
-  serial 15 0.0.0.0 {{port_qemu_ipmi}} codec VM ipmb 0x20
+  serial kcs 0.0.0.0 {{port_qemu_ipmi}} codec VM ipmb 0x20
 
   # startcmd is what to execute to start a VM associated with the
   # codec above (localhost {{port_qemu_ipmi}}).  It also starts a console serial port


### PR DESCRIPTION
For serial medium, ipmi_sim will recognize only:
- `kcs`
- `bt`
- `smic`

Then assign protocol number accrodingly.
In previous failure, we write a string "15", which
is not a valid protocol in ipmi_sim, so it goes
to "TMODE"

Signed-off-by: Conghui Chen <conghui.chen@emc.com>