### PR TITLE
Fix banner timeout exception in kcs test

### DIFF
--- a/test/functional/test_ipmi_kcs_smbios.py
+++ b/test/functional/test_ipmi_kcs_smbios.py
@@ -122,7 +122,7 @@ def verify_qemu_local_fru(expect):
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect("127.0.0.1", port=2222, username="root",
-                password="root", timeout=10)
+                password="root", timeout=10, banner_timeout=300)
     stdin, stdout, stderr = ssh.exec_command("ipmitool fru print")
     while not stdout.channel.exit_status_ready():
         pass
@@ -136,7 +136,7 @@ def verify_qemu_local_lan(expect):
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect("127.0.0.1", port=2222, username="root",
-                password="root", timeout=10)
+                password="root", timeout=10, banner_timeout=300)
     stdin, stdout, stderr = ssh.exec_command("ipmitool lan print")
     while not stdout.channel.exit_status_ready():
         pass
@@ -150,7 +150,7 @@ def verify_qemu_local_sensor(expect):
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect("127.0.0.1", port=2222, username="root",
-                password="root", timeout=10)
+                password="root", timeout=10, banner_timeout=300)
     stdin, stdout, stderr = ssh.exec_command("ipmitool sensor list")
     while not stdout.channel.exit_status_ready():
         pass
@@ -164,7 +164,7 @@ def verify_qemu_local_sdr(expect):
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect("127.0.0.1", port=2222, username="root",
-                password="root", timeout=10)
+                password="root", timeout=10, banner_timeout=300)
     stdin, stdout, stderr = ssh.exec_command("ipmitool sdr list")
     while not stdout.channel.exit_status_ready():
         pass
@@ -178,7 +178,7 @@ def verify_qemu_local_sel(expect):
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect("127.0.0.1", port=2222, username="root",
-                password="root", timeout=10)
+                password="root", timeout=10, banner_timeout=300)
     stdin, stdout, stderr = ssh.exec_command("ipmitool sel clear")
     while not stdout.channel.exit_status_ready():
         pass
@@ -196,7 +196,7 @@ def verify_qemu_local_user(expect):
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect("127.0.0.1", port=2222, username="root",
-                password="root", timeout=10)
+                password="root", timeout=10, banner_timeout=300)
     stdin, stdout, stderr = ssh.exec_command("ipmitool user list")
     while not stdout.channel.exit_status_ready():
         pass
@@ -210,7 +210,7 @@ def verify_smbios_data(expect_mfg, expect_product_name):
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect("127.0.0.1", port=2222, username="root",
-                password="root", timeout=10)
+                password="root", timeout=10, banner_timeout=300)
     stdin, stdout, stderr = ssh.exec_command("dmidecode -t1")
     while not stdout.channel.exit_status_ready():
         pass


### PR DESCRIPTION
Expanded `banner_timeout` for a paramiko client connection, from
15s to 300s.

*Background*
- **SSH banner** returns SSH version information from server to client,
which is used as a reference to config runtime client behavior.
This is caused by SSH1/SSH2 differetiation.
- Lots of cases googled report SSH banner timeout exception,
happening randomly, to well configured SSH server from paramiko
client.
- Paramiko sets a 15s timeout to read the first banner data
from socket (`packtizer` in paramiko). This is the very beginning
of data transfer, even **before handshake**, when resource could
possibly not ready from server's side. So it leads below errors
in infrasim kcs test.
- Since paramiko 1.15, `client.connect` added the parameter
`banner_timeout` for user to set the first timeout to get banner.

*Log*
Random failures in kcs test:

    ======================================================================
    ERROR: test_qemu_local_lan (test_ipmi_kcs_smbios.test_s2600kp)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/home/infrasim/infrasim-compute/test/functional/test_ipmi_kcs_smbios.py", line 307, in test_qemu_local_lan
        verify_qemu_local_lan(expect="Auth Type")
      File "/home/infrasim/infrasim-compute/test/functional/test_ipmi_kcs_smbios.py", line 139, in verify_qemu_local_lan
        password="root", timeout=10)
      File "/usr/local/lib/python2.7/dist-packages/paramiko/client.py", line 338, in connect
        t.start_client()
      File "/usr/local/lib/python2.7/dist-packages/paramiko/transport.py", line 493, in start_client
        raise e
    SSHException: Error reading SSH protocol banner
    -------------------- >> begin captured logging << --------------------
    paramiko.transport: DEBUG: starting thread (client mode): 0x172dfc10L
    paramiko.transport: DEBUG: Local version/idstring: SSH-2.0-paramiko_2.0.1
    paramiko.transport: ERROR: Exception: Error reading SSH protocol banner
    paramiko.transport: ERROR: Traceback (most recent call last):
    paramiko.transport: ERROR:   File "/usr/local/lib/python2.7/dist-packages/paramiko/transport.py", line 1738, in run
    paramiko.transport: ERROR:     self._check_banner()
    paramiko.transport: ERROR:   File "/usr/local/lib/python2.7/dist-packages/paramiko/transport.py", line 1886, in _check_banner
    paramiko.transport: ERROR:     raise SSHException('Error reading SSH protocol banner' + str(e))
    paramiko.transport: ERROR: SSHException: Error reading SSH protocol banner
    paramiko.transport: ERROR:
    --------------------- >> end captured logging << --------------------

Signed-off-by: Forrest Gu <forrest.gu@emc.com>