### PR TITLE
Bugfix/enable sigterm

### DIFF
--- a/infrasim/ipmiconsole/__init__.py
+++ b/infrasim/ipmiconsole/__init__.py
@@ -25,7 +25,6 @@ import env, sdr, common
 from infrasim.log import infrasim_log, LoggerType
 
 
-env.local_env = None
 quit_flag = False
 logger_ic = infrasim_log.get_logger(LoggerType.ipmi_console.value)
 sensor_thread_list = []

--- a/infrasim/ipmiconsole/__init__.py
+++ b/infrasim/ipmiconsole/__init__.py
@@ -12,6 +12,7 @@ import sys
 import re
 import signal
 import time
+import atexit
 
 from infrasim import daemon
 from infrasim import sshim
@@ -25,6 +26,9 @@ from infrasim.log import infrasim_log, LoggerType
 server = None
 logger_ic = infrasim_log.get_logger(LoggerType.ipmi_console.value)
 
+def atexit_cb(sig=signal.SIGTERM, stack=None):
+    _free_resource()
+    _stop_console()
 
 class IPMI_CONSOLE(threading.Thread):
     WELCOME = 'You have connected to the test server.'
@@ -153,6 +157,9 @@ def start(instance="default"):
     global logger_ic
     logger_ic = infrasim_log.get_logger(LoggerType.ipmi_console.value, instance)
     common.init_logger(instance)
+    #register the atexit call back function
+    atexit.register(atexit_cb)
+    signal.signal(signal.SIGTERM, atexit_cb)
     # initialize environment
     common.init_env(instance)
 
@@ -255,4 +262,3 @@ def console_main(instance="default"):
 
     except Exception as e:
         sys.exit(e)
-

--- a/infrasim/ipmiconsole/common.py
+++ b/infrasim/ipmiconsole/common.py
@@ -75,6 +75,10 @@ def init_env(instance):
     have a plan to give instance name to ipmi-console so that it can be attached to
     target vBMC instance.
     """
+    # Threading quit flag initilization
+    env.local_env.quit_flag = False
+
+    # Verify node instance runtime
     cur_path = os.environ["PATH"]
     os.environ["PATH"] = "{}/bin:{}".format(os.environ.get("PYTHONPATH"), cur_path)
     if not Workspace.check_workspace_exists(instance):

--- a/infrasim/ipmiconsole/env.py
+++ b/infrasim/ipmiconsole/env.py
@@ -6,10 +6,13 @@ Copyright @ 2015 EMC Corporation All Rights Reserved
 # -*- coding: utf-8 -*-
 import threading
 
+
 PORT_TELNET_TO_VBMC = 9000
 PORT_SSH_FOR_CLIENT = 9300
 VBMC_IP = "localhost"
 VBMC_PORT = 623
-#local_env is a thread-safe variable set
+
+
+# local_env is a thread-safe variable set
 local_env = threading.local()
 

--- a/infrasim/ipmiconsole/env.py
+++ b/infrasim/ipmiconsole/env.py
@@ -4,8 +4,12 @@ Copyright @ 2015 EMC Corporation All Rights Reserved
 *********************************************************
 '''
 # -*- coding: utf-8 -*-
+import threading
 
 PORT_TELNET_TO_VBMC = 9000
 PORT_SSH_FOR_CLIENT = 9300
 VBMC_IP = "localhost"
 VBMC_PORT = 623
+#local_env is a thread-safe variable set
+local_env = threading.local()
+

--- a/infrasim/racadmsim/env.py
+++ b/infrasim/racadmsim/env.py
@@ -6,8 +6,13 @@
 Copyright @ 2015 EMC Corporation All Rights Reserved
 *********************************************************
 '''
+import threading
+
 
 auth_map = {}
 racadm_data = None
 logger_r = None
 node_name = None
+#local_env is a thread-safe variable set
+local_env = threading.local()
+

--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -192,10 +192,11 @@ class test_ipmi_console_start_stop(unittest.TestCase):
             ps_ipmi_console_cmd, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)[1]
         assert start_ipmi_console_cmd in output
+        time.sleep(20)
 
         node.stop()
-        # ipmi-console polls every 3s to see vbmc status, so wait 10s for it
-        time.sleep(10)
+        # ipmi-console polls every 3s to see vbmc status, so wait 5s for it
+        time.sleep(5)
         output = run_command(
             ps_ipmi_console_cmd, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)[1]

--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -255,7 +255,6 @@ class test_ipmi_console(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
 
-        cls.channel.send('quit\n')
         cls.channel.close()
         cls.ssh.close()
 

--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -94,6 +94,8 @@ class test_ipmi_console_start_stop(unittest.TestCase):
         returncode, output = run_command(
             ipmi_start_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         os.system("ipmi-console stop")
+
+        time.sleep(1)
         ipmi_stop_cmd = 'ps ax | grep ipmi-console'
         returncode1, output1 = run_command(
             ipmi_stop_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -118,6 +120,8 @@ class test_ipmi_console_start_stop(unittest.TestCase):
         returncode, output = run_command(
             ipmi_start_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         os.system("ipmi-console stop {}".format(self.node_name))
+
+        time.sleep(1)
         ipmi_stop_cmd = 'ps ax | grep ipmi-console'
         returncode1, output1 = run_command(
             ipmi_stop_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
Register the atexit call back function for ipmiconsole and racadmsim
to response SIGTERM.
Make ipmiconsole and racadmsim sshim service thread-safe.
Soon after ipmiconsole start, it failed to response stop command,
we fix this issue now.