### PR TITLE
Added NVMe support

### DIFF
--- a/test/fixtures.py
+++ b/test/fixtures.py
@@ -27,14 +27,14 @@ class FakeConfig(object):
                             {
                                 "size": 8
                             }
-			]		
+                        ]
                     }
                 ],
                 "networks": [
                     {
                         "network_mode": "nat",
                         "device": "e1000",
-			"network_name": "dummy0"
+                        "network_name": "dummy0"
                     }
                 ]
             }

--- a/test/functional/test_scsi_page.py
+++ b/test/functional/test_scsi_page.py
@@ -62,14 +62,22 @@ def start_node(node_type):
     conf = fake_config.get_node_info()
     conf["type"] = node_type
 
-    conf["compute"]["storage_backend"] = [{
-        "type": "ahci",
-        "max_drive_per_controller": 6,
-        "drives": [{"size": 8, "file": test_img_file}]
-        }, {
-        "type": "megasas",
-        "max_drive_per_controller": 16,
-        "drives": [{
+    conf["compute"]["storage_backend"] = [
+        {
+            "type": "ahci",
+            "max_drive_per_controller": 6,
+            "drives": [
+                {
+                    "size": 8,
+                    "file": test_img_file
+                }
+            ]
+        },
+        {
+            "type": "megasas",
+            "max_drive_per_controller": 16,
+            "drives": [
+                {
                     "file": test_drive_image,
                     "format": "raw",
                     "vendor": "SEAGATE",
@@ -81,7 +89,8 @@ def start_node(node_type):
                     "scsi-id": 0,
                     "slot_number": 0,
                     "page-file": page_file
-                    }, {
+                },
+                {
                     "file": test_drive_image,
                     "format": "raw",
                     "vendor": "SEAGATE",
@@ -92,7 +101,8 @@ def start_node(node_type):
                     "cache": "none",
                     "scsi-id": 1,
                     "slot_number": 1
-                    }]
+                }
+            ]
         }
     ]
 

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -1,0 +1,149 @@
+'''
+*********************************************************
+Copyright @ 2015 EMC Corporation All Rights Reserved
+*********************************************************
+'''
+
+import unittest
+from infrasim.helper import version_parser, version_match
+
+
+class TestVersionMatch(unittest.TestCase):
+
+    def test_ge_1(self):
+        e = ">=2.10.1"
+        r = "2.11"
+        assert version_match(e, r) is True
+
+    def test_ge_2(self):
+        e = ">=2.10.1"
+        r = "2.10"
+        assert version_match(e, r) is True
+
+    def test_ge_3(self):
+        e = ">=2.10.1"
+        r = "2.9"
+        assert version_match(e, r) is False
+
+    def test_gt_1(self):
+        e = ">2.10.1"
+        r = "2.11"
+        assert version_match(e, r) is True
+
+    def test_gt_2(self):
+        e = ">2.10.1"
+        r = "2.10"
+        assert version_match(e, r) is False
+
+    def test_gt_3(self):
+        e = ">2.10.1"
+        r = "2.9"
+        assert version_match(e, r) is False
+
+    def test_eq_1(self):
+        e = "==2.10.1"
+        r = "2.11"
+        assert version_match(e, r) is False
+
+    def test_eq_2(self):
+        e = "==2.10.1"
+        r = "2.10"
+        assert version_match(e, r) is True
+
+    def test_eq_3(self):
+        e = "==2.10.1"
+        r = "2.9"
+        assert version_match(e, r) is False
+
+    def test_le_1(self):
+        e = "<=2.10.1"
+        r = "2.11"
+        assert version_match(e, r) is False
+
+    def test_le_2(self):
+        e = "<=2.10.1"
+        r = "2.10"
+        assert version_match(e, r) is True
+
+    def test_le_3(self):
+        e = "<=2.10.1"
+        r = "2.9"
+        assert version_match(e, r) is True
+
+    def test_lt_1(self):
+        e = "<2.10.1"
+        r = "2.11"
+        assert version_match(e, r) is False
+
+    def test_lt_2(self):
+        e = "<2.10.1"
+        r = "2.10"
+        assert version_match(e, r) is False
+
+    def test_lt_3(self):
+        e = "<2.10.1"
+        r = "2.9"
+        assert version_match(e, r) is True
+
+
+class TestVersionParser(unittest.TestCase):
+
+    def test_normal_expression(self):
+        e = ">=2.10.1"
+        p, v = version_parser(e)
+        assert p == ">="
+        assert v == "2.10.1"
+
+    def test_no_punctuation(self):
+        e = "2.10.1"
+        p, v = version_parser(e)
+        assert p is None
+        assert v == "2.10.1"
+
+    def test_no_revision(self):
+        e = ">="
+        p, v = version_parser(e)
+        assert p is None
+        assert v is None
+
+    def test_empty_expression(self):
+        e = ""
+        p, v = version_parser(e)
+        assert p is None
+        assert v is None
+
+    def test_less_than(self):
+        e = "<2.10.1"
+        p, v = version_parser(e)
+        assert p == "<"
+        assert v == "2.10.1"
+
+    def test_more_than(self):
+        e = ">2.10.1"
+        p, v = version_parser(e)
+        assert p == ">"
+        assert v == "2.10.1"
+
+    def test_short_revision(self):
+        e = ">=2"
+        p, v = version_parser(e)
+        assert p == ">="
+        assert v == "2"
+
+    def test_expression_with_blank(self):
+        e = " >=\t2.10.1"
+        p, v = version_parser(e)
+        assert p == ">="
+        assert v == "2.10.1"
+
+    def test_fault_punctuation(self):
+        e = "?2.10.1"
+        p, v = version_parser(e)
+        assert p is None
+        assert v == "2.10.1"
+
+    def test_fault_revision(self):
+        e = "==a.b.c"
+        p, v = version_parser(e)
+        assert p is None
+        assert v is None

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -150,6 +150,70 @@ class qemu_functions(unittest.TestCase):
         except:
             assert False
 
+    def test_set_nvme_controller(self):
+        try:
+            backend_storage_info = [{
+                "type": "nvme",
+                "cmb_size": 256,
+                "serial": "26E0A024T2VD",
+                "drives": [{"size": 8}]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+            storage.handle_parms()
+            assert "-device nvme" in storage.get_option()
+        except:
+            assert False
+
+    def test_set_nvme_controller_default_serial(self):
+        try:
+            backend_storage_info = [{
+                "type": "nvme",
+                "cmb_size": 256,
+                "drives": [{"size": 8}]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+            storage.handle_parms()
+            p = re.compile(r"-device nvme,serial=\w+,cmb_size_mb=256,drive=nvme-0,id=dev-nvme-0")
+            m = p.search(storage.get_option())
+            assert m is not None
+        except:
+            assert False
+
+    def test_set_nvme_controller_default_cmb_size(self):
+        try:
+            backend_storage_info = [{
+                "type": "nvme",
+                "serial": "26E0A024T2VD",
+                "drives": [{"size": 8}]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+            storage.handle_parms()
+            assert "-device nvme" in storage.get_option()
+            assert "cmb_size_mb=256" in storage.get_option()
+        except:
+            assert False
+
+    def test_set_nvme_controller_invalid_cmb_size(self):
+        try:
+            backend_storage_info = [{
+                "type": "nvme",
+                "cmb_size": 255,
+                "drives": [{"size": 8}]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+        except ArgsNotCorrect as e:
+            assert "CMB size" in e.value
+        else:
+            assert False
+
     def test_set_lsi_storage_controller(self):
         try:
             backend_storage_info = [{


### PR DESCRIPTION
For NVMe option `cmb_size_mb`, we customize test to be run only
on qemu version `>=2.10`. This feature is implemented by a
decorator in infrasim.helper.

Move concrete behavior and attribute of IDEDrvie and SCSIDrive
to their derived class, instead of being in CBaseDrive. Based on
this, we provide NVMeController as a derived class from
CBaseDrive.

**kind of weird**...but we decided to make NVMeController inherits
CBaseDrive instead of CBaseStorageController, due to it needs a
drive backend.

Signed-off-by: bcyan <448162474@qq.com>