### PR TITLE
Fix stop a stopped ipmi-console raised exception

### DIFF
--- a/infrasim/ipmiconsole/__init__.py
+++ b/infrasim/ipmiconsole/__init__.py
@@ -242,6 +242,9 @@ def stop(instance="default"):
         logger_ic.warning("> {}".format(ps_cmd))
         _, pid = run_command(cmd=ps_cmd)
         logger_ic.warning("ipmi console pid got: {}".format(pid))
+        if not pid:
+            logger_ic.warning("ipmi console for instance {} is not running".format(instance))
+            return
 
         os.kill(int(pid), signal.SIGTERM)
     except:


### PR DESCRIPTION
When a user tries to stop an ipmi-console instance which is not running,
it will try to find the process in ps and get pid "", then try to
convert it to int, then fail with message "invalid literal for int()
with base 10: ''".