### PR TITLE
Enable share-rw for block device

### DIFF
--- a/infrasim/__init__.py
+++ b/infrasim/__init__.py
@@ -1,4 +1,5 @@
 import subprocess
+import inspect
 import pkg_resources
 from .log import infrasim_log, LoggerType
 
@@ -79,6 +80,8 @@ def has_option(config, *args):
 class InfraSimError(Exception):
     def __init__(self, value):
         self.value = value
+        logger.exception("{}, stack:\n{}".format(self.value,
+                         str(inspect.stack()[1:]).replace("), (", "),\n(")))
 
     def __str__(self):
         return repr(self.value)
@@ -108,4 +111,3 @@ class NodeAlreadyRunning(InfraSimError):
 
 class WorkspaceExisting(InfraSimError):
     pass
-

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -628,13 +628,14 @@ class CBaseDrive(CElement):
         self.__wwn = None
         self.__bootindex = None
         self.__version = None
+        self.__share_rw = False
+        self.__page_file = None
 
         # host option
         self.__cache = None
         self.__aio = None
         self.__drive_file = None
         self.__format = None
-        self.__page_file = None
         self.__l2_cache_size = None  # unit: byte
         self.__refcount_cache_size = None  # unit: byte
         self.__cluster_size = None  # unit: KB
@@ -656,6 +657,9 @@ class CBaseDrive(CElement):
             self.logger.exception("[CBaseDrive] page file {0} doesnot exist".format(self.__page_file))
             raise ArgsNotCorrect("[CBaseDrive] page file {0} doesnot exist".format(self.__page_file))
 
+        if not isinstance(self.__share_rw, bool):
+            raise ArgsNotCorrect("[CBaseDrive] share-rw is not boolean: {}".format(self.__share_rw))
+
     @property
     def serial(self):
         return self.__serial
@@ -668,18 +672,20 @@ class CBaseDrive(CElement):
         self.__bootindex = self._drive_info.get("bootindex")
         self.__serial = self._drive_info.get("serial")
         self.__version = self._drive_info.get("version")
+        self.__wwn = self._drive_info.get("wwn")
+        self.__share_rw = self._drive_info.get("share-rw", False)
+        self.__page_file = self._drive_info.get("page-file")
+
         self.__format = self._drive_info.get("format", "qcow2")
         self.__cache = self._drive_info.get("cache", "writeback")
         self.__aio = self._drive_info.get("aio")
-        self.__size = self._drive_info.get("size", 8)
         self.__drive_file = self._drive_info.get("file")
-        self.__wwn = self._drive_info.get("wwn")
-        self.__page_file = self._drive_info.get("page-file")
-
         self.__l2_cache_size = self._drive_info.get("l2-cache-size")
         self.__refcount_cache_size = self._drive_info.get("refcount-cache-size")
         self.__cluster_size = self._drive_info.get("cluster-size")
         self.__preallocation_mode = self._drive_info.get("preallocation")
+
+        self.__size = self._drive_info.get("size", 8)
 
         # assume the files starts with "/dev/" are block device
         # all the block devices are assumed to be raw format
@@ -776,6 +782,9 @@ class CBaseDrive(CElement):
 
         if self.__page_file:
             self._dev_attrs["page_file"] = self.__page_file
+
+        if self.__share_rw:
+            self._dev_attrs["share-rw"] = self.__share_rw
 
 
 class SCSIDrive(CBaseDrive):

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -541,6 +541,60 @@ class qemu_functions(unittest.TestCase):
         except:
             assert False
 
+    def test_enable_drive_share_rw(self):
+        try:
+            backend_storage_info = [{
+                "type": "megasas-gen2",
+                "max_drive_per_controller": 6,
+                "drives": [{
+                    "size": 8,
+                    "file": "/tmp/sda.img",
+                    "share-rw": True
+                }]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+            storage.handle_parms()
+            assert "share-rw=True" in storage.get_option()
+        except:
+            assert False
+
+    def test_disable_drive_share_rw(self):
+        try:
+            backend_storage_info = [{
+                "type": "megasas-gen2",
+                "max_drive_per_controller": 6,
+                "drives": [{
+                    "size": 8,
+                    "file": "/tmp/sda.img",
+                    "share-rw": False
+                }]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+            storage.handle_parms()
+            assert "share-rw" not in storage.get_option()
+        except:
+            assert False
+
+    def test_fault_drive_share_rw(self):
+        try:
+            backend_storage_info = [{
+                "type": "megasas-gen2",
+                "max_drive_per_controller": 6,
+                "drives": [{
+                    "size": 8,
+                    "file": "/tmp/sda.img",
+                    "share-rw": "fake"
+                }]
+            }]
+            storage = model.CBackendStorage(backend_storage_info)
+            storage.init()
+            storage.precheck()
+        except ArgsNotCorrect as e:
+            assert "share-rw is not boolean" in e.value
 
     def test_set_smbios(self):
         with open(config.infrasim_default_config, "r") as f_yml:


### PR DESCRIPTION
Added `share-rw` support for block device, which can be parsed
as an attribute of CBaseDrive. It's expected to be a boolean,
which means you need to specify `true`, `false`, `on`, `off` in yml.

Added type protection and unit test on `share-rw`.

Record log and stack for any InfraSimError, so developers won't
have to write one line to log and one line to raise exception.
Now only raise statement is needed.