### PR TITLE
Fix ipmi console test failure

### DIFF
--- a/infrasim/ipmiconsole/__init__.py
+++ b/infrasim/ipmiconsole/__init__.py
@@ -237,7 +237,7 @@ def stop(instance="default"):
         else:
             process_name = "ipmi-console start {}".format(instance)
 
-        ps_cmd = r'ps ax | grep "{}" | cut -d " " -f2 | head -n1'.format(process_name)
+        ps_cmd = r'ps ax | grep "{}" | cut -d " " -f1 | head -n1'.format(process_name)
         logger_ic.warning("Fail to find ipmi console pid file, check by:")
         logger_ic.warning("> {}".format(ps_cmd))
         _, pid = run_command(cmd=ps_cmd)

--- a/infrasim/model.py
+++ b/infrasim/model.py
@@ -823,7 +823,7 @@ class SCSIDrive(CBaseDrive):
         self.__bus = bus
 
     def get_uniq_name(self):
-        return "{}-{}".format(self.__bus, self.__index)
+        return "{}-{}".format(self.__bus, self.index)
 
     def set_scsi_id(self, scsi_id):
         self._scsi_id = scsi_id

--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -195,12 +195,18 @@ class test_ipmi_console_start_stop(unittest.TestCase):
         time.sleep(20)
 
         node.stop()
-        # ipmi-console polls every 3s to see vbmc status, so wait 5s for it
-        time.sleep(5)
-        output = run_command(
-            ps_ipmi_console_cmd, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)[1]
-        assert start_ipmi_console_cmd not in output
+
+        # ipmi-console polls every 3s to see vbmc status, wait a while for
+        # possible resource collection
+        for _ in range(10):
+            time.sleep(3)
+            output = run_command(
+                ps_ipmi_console_cmd, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)[1]
+            if start_ipmi_console_cmd not in output:
+                break
+        else:
+            assert False
 
     def test_ipmi_console_stops_followed_by_node_destroy(self):
         node_info = FakeConfig().get_node_info()
@@ -229,12 +235,18 @@ class test_ipmi_console_start_stop(unittest.TestCase):
 
         node.stop()
         node.terminate_workspace()
-        # ipmi-console polls every 3s to see vbmc status, so wait 5s for it
-        time.sleep(5)
-        output = run_command(
-            ps_ipmi_console_cmd, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)[1]
-        assert start_ipmi_console_cmd not in output
+
+        # ipmi-console polls every 3s to see vbmc status, wait a while for
+        # possible resource collection
+        for _ in range(10):
+            time.sleep(3)
+            output = run_command(
+                ps_ipmi_console_cmd, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)[1]
+            if start_ipmi_console_cmd not in output:
+                break
+        else:
+            assert False
 
 
 class test_ipmi_console(unittest.TestCase):

--- a/test/functional/test_scsi_page.py
+++ b/test/functional/test_scsi_page.py
@@ -88,7 +88,6 @@ def start_node(node_type):
                     "cache": "none",
                     "scsi-id": 0,
                     "slot_number": 0,
-                    "share-rw": "true",
                     "page-file": page_file
                 },
                 {
@@ -101,7 +100,6 @@ def start_node(node_type):
                     "wwn": "0x5000C500852E3141",
                     "cache": "none",
                     "scsi-id": 1,
-                    "share-rw": "true",
                     "slot_number": 1
                 }
             ]


### PR DESCRIPTION
How ipmi-console stop after vBMC stop:
- At first, ipmi-console starts a `monitor thread` from main thread
- Monitor thread is in charge of monitoring vBMC alive status,
  once vBMC process stops, it go to a `stop` procedure, which sends
  SIGTERM then set a global `quit_flag`
- Above monitor is a polling in a `3s` cadence, and needs scheduling,
  and resource release

Test with 5s in cleaning stage randomly fails. See what's going on
with 10s in cleaning stage.