### PR TITLE
Fix ipmi console test failure

### DIFF
--- a/test/functional/test_ipmi_console.py
+++ b/test/functional/test_ipmi_console.py
@@ -245,8 +245,8 @@ class test_ipmi_console_start_stop(unittest.TestCase):
                 stderr=subprocess.PIPE)[1]
             if start_ipmi_console_cmd not in output:
                 break
-            else:
-                assert False
+        else:
+            assert False
 
 
 class test_ipmi_console(unittest.TestCase):


### PR DESCRIPTION
Added event log in ipmi-console start and stop procedure, to
record pid and decision path.
Fixed test issue, a wrong indent by IDE leads wrong test logic.