### PR TITLE
Hot Fix for mointor service start issues

### DIFF
--- a/infrasim/monitor/__init__.py
+++ b/infrasim/monitor/__init__.py
@@ -20,4 +20,4 @@ def start(instance, host, port):
     app.logger.addHandler(mlog.handlers)
 
     api.init_app(app)
-    app.run(host=host, port=port)
+    app.run(host=host, port=int(port))

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ nose-cov==1.6
 pyyaml==3.11
 requests==2.11.1
 texttable==0.8.7
+flask >=0.12.2
+flask-restplus >=0.10.1


### PR DESCRIPTION
1. Monitor service relies on flask/flask-restplus, so add them into requirements.txt.
2. Fix type error, feed int type to parameter of flask app port. 
3. Dos2unix for monitor init file.