### PR TITLE
bug fix: vbmc.conf can not support legacy openipmi

### DIFF
--- a/infrasim/model/tasks/bmc.py
+++ b/infrasim/model/tasks/bmc.py
@@ -27,6 +27,7 @@ class CBMC(Task):
         self.__bmc = bmc_info
         self.__address = None
         self.__channel = None
+        self.__gem_enable = False
         self.__lan_interface = None
         self.__lancontrol_script = ""
         self.__chassiscontrol_script = ""
@@ -249,7 +250,6 @@ class CBMC(Task):
             bmc_conf = f.read()
         template = jinja2.Template(bmc_conf)
         bmc_conf = template.render(startcmd_script=self.__startcmd_script,
-                                   workspace=self.__workspace,
                                    lan_channel=self.__channel,
                                    chassis_control_script=self.__chassiscontrol_script,
                                    lan_control_script=self.__lancontrol_script,
@@ -267,7 +267,9 @@ class CBMC(Task):
                                    kill_wait=self.__kill_wait,
                                    startnow=self.__startnow,
                                    historyfru=self.__historyfru,
-                                   sol_enabled=self.__sol_enabled)
+                                   sol_enabled=self.__sol_enabled,
+                                   gem_enable=self.__gem_enable,
+                                   workspace=self.__workspace)
 
         with open(dst, "w") as f:
             f.write(bmc_conf)
@@ -276,6 +278,7 @@ class CBMC(Task):
     def init(self):
         self.__address = self.__bmc.get('address', 0x20)
         self.__channel = self.__bmc.get('channel', 1)
+        self.__gem_enable = self.__bmc.get("gem_enable", False)
 
         if 'interface' in self.__bmc:
             self.__lan_interface = self.__bmc['interface']

--- a/template/vbmc.conf
+++ b/template/vbmc.conf
@@ -52,7 +52,7 @@ set_working_mc 0x20
   startcmd "{{startcmd_script}}"
 
   # oem_file_path is the place to store the nvme related data for oem command.
-  workspace "{{workspace}}"
+  {% if not gem_enable %}#{% endif %} workspace "{{workspace}}"
 
   # Set up telnet session for ipmi simulator on port {{port_ipmi_console}}
   console 0.0.0.0 {{port_ipmi_console}}


### PR DESCRIPTION
1.add gem_enable in bmc in yaml:
  bmc:
    gem_enable: True
2.modify the template of vbmc.
  make the workspace fold depend on gem_enable.