### PR TITLE
infrasim/model: add peer bmc support

### DIFF
--- a/infrasim/model/tasks/compute.py
+++ b/infrasim/model/tasks/compute.py
@@ -92,11 +92,13 @@ class CCompute(Task, CElement):
     @run_in_namespace
     def precheck(self):
         # check if qemu-system-x86_64 exists
-        try:
-            run_command("which {}".format(self.__qemu_bin))
-        except CommandRunFailed:
-            self.logger.exception("[Compute] Can not find file {}".format(self.__qemu_bin))
-            raise CommandNotFound(self.__qemu_bin)
+        # if self.__qemu_bin is an absolute path, check if it exists
+        if not self.__qemu_bin.startswith("qemu"):
+            try:
+                run_command("which {}".format(self.__qemu_bin))
+            except CommandRunFailed:
+                self.logger.exception("[Compute] Can not find file {}".format(self.__qemu_bin))
+                raise CommandNotFound(self.__qemu_bin)
 
         # check if smbios exists
         if not os.path.isfile(self.__smbios):

--- a/template/vbmc.conf
+++ b/template/vbmc.conf
@@ -80,7 +80,12 @@ set_working_mc 0x20
   #    # valid name    passw      priv-lim max-sess allowed-auths
   user 1 true  ""      "test"     user     10       none md2 md5 straight
   user 2 true  "{{username}}" "{{password}}" admin    10       none md2 md5 straight
-
+  {% if peers %}
+  {% for peer in peers %}
+  # peer BMC({{peer.addr}}) information
+  peer {{peer.addr}} {{peer.interface}} {{peer.user}} {{peer.password}} {{peer.host}}
+  {% endfor %}
+  {% endif %}
   {% if sol_enabled %}
   sol "{{sol_device}}" 115200 history=4000 historyfru={{historyfru}}
   {% endif %}


### PR DESCRIPTION
for enabling peer BMC, add the following attributes in YAML config:

compute:
    ....
bmc:
    ...
    peer-bmcs:
    - addr: 0x1e
      user: "test"
      password: "test"
      interface: "lanplus"
      host: "10.62.59.xx"
    - addr: 0x1c
      ...
    ...

Note: all the attributes are required to access peer BMC, default
the peer bmc is disabled.