### PR TITLE
Add nose-exclude plugin.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ requests==2.11.1
 texttable==0.8.7
 flask >=0.12.2
 flask-restplus >=0.10.1
+nose-exclude==0.5


### PR DESCRIPTION
1. Current nosetests framework only support to exclude test file/pattern matched test function, but not supporting to exclude test class. 
So here add nose-exclude plugin to support excluding test class from test directory.
2. This is also for enabling jenkins job to exclude test on condition.
@chenge3 @xiar @XiaowenJiang 