### PR TITLE
infrasim: add trace for seabios and guest os

### DIFF
--- a/infrasim/config.py
+++ b/infrasim/config.py
@@ -41,3 +41,6 @@ infrasim_node_config_map = os.path.join(infrasim_home, ".node_map")
 # inital configuration file after running infrasim-init
 # and this is a copy for all the other nodes
 infrasim_default_config = os.path.join(infrasim_node_config_map, "default.yml")
+
+# infrasim log location
+infrasim_log_dir = "/var/log/infrasim"

--- a/infrasim/ipmi.py
+++ b/infrasim/ipmi.py
@@ -42,8 +42,7 @@ def start_ipmi(conf_file=config.infrasim_default_config):
         bmc = CBMC(conf.get('bmc', {}))
         node_name = conf["name"] if "name" in conf else "node-0"
         bmc.set_task_name("{}-bmc".format(node_name))
-        bmc.set_log_path("/var/log/infrasim/{}/openipmi.log".
-                         format(node_name))
+        bmc.set_log_path(os.path.join(config.infrasim_log_dir, node_name, "openipmi.log"))
         bmc.set_type(conf["type"])
         bmc.enable_sol(False)
         bmc.set_workspace(node.workspace.get_workspace())

--- a/infrasim/log.py
+++ b/infrasim/log.py
@@ -4,8 +4,9 @@ import os
 from enum import Enum
 import gzip
 import shutil
+from infrasim import config
 
-infrasim_logdir = "/var/log/infrasim"
+infrasim_logdir = config.infrasim_log_dir
 EXCEPT_LEVEL_NUM = 35
 
 

--- a/infrasim/model/__init__.py
+++ b/infrasim/model/__init__.py
@@ -41,6 +41,7 @@ from infrasim.model.elements.machine import CMachine
 from infrasim.model.elements.pci_passthrough import CPCIEPassthrough
 from infrasim.model.elements.guest_agent import GuestAgent
 from infrasim.model.elements.serial import CSerial
+from infrasim.model.elements.trace import QTrace
 
 from infrasim.model.tasks.compute import CCompute
 from infrasim.model.tasks.bmc import CBMC
@@ -84,4 +85,5 @@ __all__ = ["CNode",
            "CChassis",
            "CPCIEPassthrough",
            "GuestAgent",
-           "CSerial"]
+           "CSerial",
+           "QTrace"]

--- a/infrasim/model/core/node.py
+++ b/infrasim/model/core/node.py
@@ -120,8 +120,7 @@ class CNode(object):
         bmc_obj.set_priority(1)
         bmc_obj.set_task_name("{}-bmc".format(self.__node_name))
         bmc_obj.enable_sol(self.__sol_enabled)
-        bmc_obj.set_log_path("/var/log/infrasim/{}/openipmi.log".
-                             format(self.__node_name))
+        bmc_obj.set_log_path(os.path.join(config.infrasim_log_dir, self.__node_name, "openipmi.log"))
         bmc_obj.set_node_name(self.__node['name'])
         self.__tasks_list.append(bmc_obj)
 
@@ -132,8 +131,7 @@ class CNode(object):
         compute_obj.enable_sol(self.__sol_enabled)
         compute_obj.set_priority(2)
         compute_obj.set_task_name("{}-node".format(self.__node_name))
-        compute_obj.set_log_path("/var/log/infrasim/{}/qemu.log".
-                                 format(self.__node_name))
+        compute_obj.set_log_path(os.path.join(config.infrasim_log_dir, self.__node_name, "qemu.log"))
         self.__tasks_list.append(compute_obj)
 
         if "type" in self.__node and "dell" in self.__node["type"]:
@@ -143,8 +141,7 @@ class CNode(object):
             racadm_obj.set_priority(3)
             racadm_obj.set_node_name(self.__node_name)
             racadm_obj.set_task_name("{}-racadm".format(self.__node_name))
-            racadm_obj.set_log_path("/var/log/infrasim/{}/racadm.log".
-                                    format(self.__node_name))
+            racadm_obj.set_log_path(os.path.join(config.infrasim_log_dir, self.__node_name, "racadm.log"))
             self.__tasks_list.append(racadm_obj)
 
         # Set interface
@@ -199,8 +196,7 @@ class CNode(object):
             monitor_obj.set_priority(4)
             monitor_obj.set_node_name(self.__node_name)
             monitor_obj.set_task_name("{}-monitor".format(self.__node_name))
-            monitor_obj.set_log_path("/var/log/infrasim/{}/monitor.log".
-                                     format(self.__node_name))
+            monitor_obj.set_log_path(os.path.join(config.infrasim_log_dir, self.__node_name, "monitor.log"))
             self.__tasks_list.append(monitor_obj)
 
         self.workspace = Workspace(self.__node)

--- a/infrasim/model/elements/__init__.py
+++ b/infrasim/model/elements/__init__.py
@@ -4,4 +4,4 @@ __all__ = ["chardev", "cpu",
            "pcie_rootport", "pcie_upstream", "pcie_downstream",
            "pcie_topology", "pci_bridge", "pci_topo", "fw_cfg", "ses",
            "storage", "storage_ahci", "storage_lsi", "storage_mega",
-           "machine", "pci_passthrough", "cdrom", "guest_agent", "serial"]
+           "machine", "pci_passthrough", "cdrom", "guest_agent", "serial", "trace"]

--- a/infrasim/model/elements/trace.py
+++ b/infrasim/model/elements/trace.py
@@ -1,0 +1,61 @@
+'''
+*********************************************************
+Copyright @ 2015 EMC Corporation All Rights Reserved
+*********************************************************
+'''
+# -*- coding: utf-8 -*-
+
+import os
+from infrasim import config
+from infrasim.model.core.element import CElement
+from infrasim.model.elements.chardev import CCharDev
+from infrasim.model.elements.serial import CSerial
+
+
+class QTrace(CElement):
+    def __init__(self, trace_settings, workspace):
+        super(QTrace, self).__init__()
+        self.__seabios_out = trace_settings.get("seabios")
+        self.__guest_out = trace_settings.get("guest")
+
+        self.__chardev_for_so = None
+
+        self.__chardev_for_go = None
+        self.__serial_for_go = None
+        self.__node_name = workspace.split('/')[-1]
+
+    def precheck(self):
+        pass
+
+    def init(self):
+        if self.__seabios_out == "on":
+            self.__chardev_for_so = CCharDev({
+                "backend": "file",
+                "path": os.path.join(config.infrasim_log_dir, self.__node_name, "seabios.log"),
+            })
+            self.__chardev_for_so.set_id("seabios")
+            self.__chardev_for_so.init()
+
+        if self.__guest_out == "on":
+            self.__chardev_for_go = CCharDev({
+                "backend": "file",
+                "path": os.path.join(config.infrasim_log_dir, self.__node_name, "guest.log")
+            })
+
+            self.__chardev_for_go.set_id("guest")
+            self.__chardev_for_go.init()
+
+            self.__serial_for_go = CSerial(self.__chardev_for_go, {"index": "0"})
+            self.__serial_for_go.init()
+
+    def handle_parms(self):
+        if self.__chardev_for_so:
+            self.__chardev_for_so.handle_parms()
+            self.add_option("{} -device isa-debugcon,iobase=0x402,chardev=seabios".format(
+                self.__chardev_for_so.get_option()))
+
+        if self.__chardev_for_go and self.__serial_for_go:
+            self.__chardev_for_go.handle_parms()
+            self.__serial_for_go.handle_parms()
+            self.add_option(self.__chardev_for_go.get_option())
+            self.add_option(self.__serial_for_go.get_option())

--- a/infrasim/model/tasks/compute.py
+++ b/infrasim/model/tasks/compute.py
@@ -30,6 +30,7 @@ from infrasim.model.elements.pci_passthrough import CPCIEPassthrough
 from infrasim.model.elements.cdrom import IDECdrom
 from infrasim.model.elements.guest_agent import GuestAgent
 from infrasim.model.elements.serial import CSerial
+from infrasim.model.elements.trace import QTrace
 
 
 class CCompute(Task, CElement):
@@ -289,6 +290,11 @@ class CCompute(Task, CElement):
         has_guest_agent = self.__compute.get('guest-agent')
         if has_guest_agent or has_guest_agent == 'on':
             self.__element_list.append(GuestAgent(self.get_workspace()))
+
+        # add debug option
+        trace_info = self.__compute.get("trace")
+        if trace_info:
+            self.__element_list.append(QTrace(trace_info, self.get_workspace()))
 
         for ppi in self.__compute.get("pcie-passthrough", []):
             ppi_obj = CPCIEPassthrough(ppi)

--- a/infrasim/qemu.py
+++ b/infrasim/qemu.py
@@ -66,7 +66,7 @@ def start_qemu(conf_file=config.infrasim_default_config):
         workspace = os.path.join(config.infrasim_home, node_name)
         if not os.path.isdir(workspace):
             os.mkdir(workspace)
-        path_log = "/var/log/infrasim/{}".format(node_name)
+        path_log = os.path.join(config.infrasim_log_dir, node_name)
         compute.logger = infrasim_log.get_logger(LoggerType.model.value, node_name)
         if not os.path.isdir(path_log):
             os.mkdir(path_log)
@@ -78,7 +78,7 @@ def start_qemu(conf_file=config.infrasim_default_config):
         # Set attributes
         compute.enable_sol(sol_enabled)
         compute.set_task_name("{}-node".format(node_name))
-        compute.set_log_path("/var/log/infrasim/{}/qemu.log".format(node_name))
+        compute.set_log_path(os.path.join(path_log, "qemu.log"))
         compute.set_workspace(workspace)
         compute.set_type(conf["type"])
 
@@ -128,7 +128,7 @@ def stop_qemu(conf_file=config.infrasim_default_config):
         # Set attributes
         compute.logger = infrasim_log.get_logger(LoggerType.model.value, node_name)
         compute.set_task_name("{}-node".format(node_name))
-        compute.set_log_path("/var/log/infrasim/{}/qemu.log".format(node_name))
+        compute.set_log_path(os.path.join(config.infrasim_log_dir, node_name, "qemu.log"))
         compute.set_workspace(os.path.join(config.infrasim_home, node_name))
         compute.set_type(conf["type"])
 

--- a/infrasim/workspace.py
+++ b/infrasim/workspace.py
@@ -1,7 +1,7 @@
 import os
 import yaml
 import shutil
-import config
+from infrasim import config
 import subprocess
 from yaml_loader import YAMLLoader
 from . import has_option, InfraSimError
@@ -87,7 +87,7 @@ class Workspace(object):
             os.mkdir(self._workspace)
 
         # II. Create log folder
-        path_log = "/var/log/infrasim/{}".format(self._workspace_name)
+        path_log = os.path.join(config.infrasim_log_dir, self._workspace_name)
         if not os.path.exists(path_log):
             os.mkdir(path_log)
 
@@ -199,7 +199,7 @@ class ChassisWorkspace(Workspace):
             os.mkdir(self._workspace)
 
         # II. Create log folder
-        path_log = "/var/log/infrasim/{}".format(self._workspace_name)
+        path_log = os.path.join(config.infrasim_log_dir, self._workspace_name)
         if not os.path.exists(path_log):
             os.mkdir(path_log)
 


### PR DESCRIPTION
add the following configuration to enable the trace:

compute:
    trace:
        guest: 'on'
        seabios: 'on'

the default log will be at /var/log/<node name>/{seabios.log, guest.log}