### PR TITLE
Zhenzan: Fix sol confliction for multiple nodes

### DIFF
--- a/infrasim/model/core/node.py
+++ b/infrasim/model/core/node.py
@@ -112,6 +112,7 @@ class CNode(object):
             socat_obj.logger = self.__logger
             socat_obj.set_priority(0)
             socat_obj.set_task_name("{}-socat".format(self.__node_name))
+            socat_obj.set_node_name(self.__node['name'])
             self.__tasks_list.append(socat_obj)
 
         bmc_info = self.__node.get('bmc', {})

--- a/infrasim/model/tasks/bmc.py
+++ b/infrasim/model/tasks/bmc.py
@@ -378,9 +378,9 @@ class CBMC(Task):
         if self.__sol_device:
             pass
         elif self.get_workspace():
-            self.__sol_device = os.path.join(self.get_workspace(), ".pty0")
+            self.__sol_device = os.path.join(self.get_workspace(), ".pty0_{}".format(self.__node_name))
         else:
-            self.__sol_device = os.path.join(config.infrasim_etc, "pty0")
+            self.__sol_device = os.path.join(config.infrasim_etc, "pty0_{}".format(self.__node_name))
 
         if 'config_file' in self.__bmc:
             self.__config_file = self.__bmc['config_file']

--- a/infrasim/model/tasks/socat.py
+++ b/infrasim/model/tasks/socat.py
@@ -22,12 +22,16 @@ class CSocat(Task):
         # Node wise attributes
         self.__socket_serial = ""
         self.__sol_device = ""
+        self.__node_name = None
 
     def set_socket_serial(self, o):
         self.__socket_serial = o
 
     def set_sol_device(self, device):
         self.__sol_device = device
+
+    def set_node_name(self, o):
+        self.__node_name = o
 
     def precheck(self):
 
@@ -49,9 +53,9 @@ class CSocat(Task):
         if self.__sol_device:
             pass
         elif self.get_workspace():
-            self.__sol_device = os.path.join(self.get_workspace(), ".pty0")
+            self.__sol_device = os.path.join(self.get_workspace(), ".pty0_{}".format(self.__node_name))
         else:
-            self.__sol_device = os.path.join(config.infrasim_etc, "pty0")
+            self.__sol_device = os.path.join(config.infrasim_etc, "pty0_{}".format(self.__node_name))
 
         if self.__socket_serial:
             pass

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -1667,13 +1667,15 @@ class socat_configuration(unittest.TestCase):
         socat.stop_socat()
 
     def test_default_socat(self):
+        node_name = "default"
         socat_obj = model.CSocat()
 
+        socat_obj.set_node_name(node_name)
         socat_obj.init()
         socat_obj.precheck()
         cmd = socat_obj.get_commandline()
 
-        assert "pty,link={}/pty0,waitslave".format(config.infrasim_etc) in cmd
+        assert "pty,link={0}/pty0_{1},waitslave".format(config.infrasim_etc, node_name) in cmd
         assert "unix-listen:{}/serial,fork".format(config.infrasim_etc) in cmd
 
     def test_change_sol_device(self):


### PR DESCRIPTION
Currently all nodes use .pty0 for socat, but ipmi_sim will use lock name
as LCK...pty0, so we can only enable sol for one node since ipmi_sim for
other nodes won't be able to pass lock check.