### PR TITLE
Ntb and ioat parameter support

### DIFF
--- a/infrasim/model/elements/__init__.py
+++ b/infrasim/model/elements/__init__.py
@@ -2,6 +2,6 @@ __all__ = ["chardev", "cpu",
            "drive", "drive_ide", "drive_nvme", "drive_scsi",
            "ipmi", "memory", "monitor", "network", "pcie_port",
            "pcie_rootport", "pcie_upstream", "pcie_downstream",
-           "pcie_topology", "pci_bridge", "pci_topo", "fw_cfg", "ses", "ntb",
+           "pcie_topology", "pci_bridge", "pci_topo", "fw_cfg", "ses", "ntb", "dma_engine",
            "storage", "storage_ahci", "storage_lsi", "storage_mega",
            "machine", "pci_passthrough", "cdrom", "guest_agent", "serial", "trace"]

--- a/infrasim/model/elements/__init__.py
+++ b/infrasim/model/elements/__init__.py
@@ -2,6 +2,6 @@ __all__ = ["chardev", "cpu",
            "drive", "drive_ide", "drive_nvme", "drive_scsi",
            "ipmi", "memory", "monitor", "network", "pcie_port",
            "pcie_rootport", "pcie_upstream", "pcie_downstream",
-           "pcie_topology", "pci_bridge", "pci_topo", "fw_cfg", "ses",
+           "pcie_topology", "pci_bridge", "pci_topo", "fw_cfg", "ses", "ntb",
            "storage", "storage_ahci", "storage_lsi", "storage_mega",
            "machine", "pci_passthrough", "cdrom", "guest_agent", "serial", "trace"]

--- a/infrasim/model/elements/dma_engine.py
+++ b/infrasim/model/elements/dma_engine.py
@@ -1,0 +1,52 @@
+'''
+*********************************************************
+Copyright @ 2018 Dell EMC Corporation All Rights Reserved
+*********************************************************
+'''
+# -*- coding: utf-8 -*-
+from infrasim.model.core.element import CElement
+from infrasim import ArgsNotCorrect
+
+
+class CDMAEngine(CElement):
+    '''
+    DmaEngine provides the function related with IOAT DMA Device.
+    Check its parameters and generate argument string.
+    '''
+
+    def __init__(self, info):
+        super(CDMAEngine, self).__init__()
+        self.__dma_info = info
+        self.__count = 0
+        self.id = None
+        self.bus = None
+        self.addr = None
+
+    def precheck(self):
+        if self.id is None:
+            raise ArgsNotCorrect("NTB's id is mandatory!")
+
+        if self.bus is None:
+            raise ArgsNotCorrect("NTB's bus is mandatory!")
+
+    def init(self):
+        self.id = self.__dma_info["id"]
+        self.bus = self.__dma_info.get("bus", "pcie.0")
+        self.addr = self.__dma_info.get("addr", "0.0")
+        self.__count = self.__dma_info.get("count", 8)
+
+    def handle_parms(self):
+        dev_nr = self.addr.split(".")[0]
+        for idx in range(0, self.__count):
+            args = {}
+            args["id"] = "{}_{}".format(self.id, idx)
+            args["bus"] = self.bus
+            args["addr"] = "{}.{}".format(dev_nr, idx)
+            args["multifunction"] = 'on'
+
+            opt_list = []
+            opt_list.append("-device ioat_dma")
+            for k, v in args.items():
+                opt_list.append("{}={}".format(k, v))
+
+            self.add_option(",".join(opt_list))

--- a/infrasim/model/elements/ntb.py
+++ b/infrasim/model/elements/ntb.py
@@ -1,0 +1,82 @@
+'''
+*********************************************************
+Copyright @ 2018 Dell EMC Corporation All Rights Reserved
+*********************************************************
+'''
+# -*- coding: utf-8 -*-
+from infrasim.model.core.element import CElement
+from infrasim import ArgsNotCorrect
+
+
+class CNTB(CElement):
+    '''
+    SkxNtb provides the function related with Intel Skylake NTB Device.
+    Check its parameters and generate argument string.
+    '''
+
+    def __init__(self, info):
+        super(CNTB, self).__init__()
+        self.__ntb_info = info
+        self.__bar1_exp = None
+        self.__bar2_exp = None
+        self.__link_rx = None
+        self.__link_tx = None
+        self.id = None
+        self.bus = None
+        self.addr = None
+
+    def precheck(self):
+        if self.id is None:
+            raise ArgsNotCorrect("NTB's id is mandatory!")
+
+        if self.bus is None:
+            raise ArgsNotCorrect("NTB's bus is mandatory!")
+
+        if (self.__bar1_exp < 12 or self.__bar1_exp > 47):
+            raise ArgsNotCorrect("exponent of bar1 size must in range [12,47].")
+
+        if (self.__bar2_exp < 12 or self.__bar2_exp > 47):
+            raise ArgsNotCorrect("exponent of bar2 size must in range [12,47].")
+
+        if self.__link_rx is None:
+            raise ArgsNotCorrect("peer device link_rx is mandatory.")
+
+        if self.__link_tx is None:
+            raise ArgsNotCorrect("local device is mandatory.")
+
+    def init(self):
+        self.id = self.__ntb_info["id"]
+        self.bus = self.__ntb_info.get("bus", "pcie.0")
+        self.addr = self.__ntb_info.get("addr", "0.0")
+        self.__bar1_exp = self.__ntb_info.get("bar1_exp", 0)
+        self.__bar2_exp = self.__ntb_info.get("bar2_exp", 0)
+        self.__link_rx = self.__ntb_info.get("peer_rx")
+        self.__link_tx = self.__ntb_info.get("local")
+        self.__peer_memoryblock = self.__ntb_info.get("peer_memory")
+
+    def handle_parms(self):
+        args = {}
+        args["id"] = self.id
+        args["bus"] = self.bus
+        args["addr"] = self.addr
+        args["region1size"] = self.__bar1_exp
+        args["region2size"] = self.__bar2_exp
+
+        rx_id = "{}_rx".format(self.id)
+        tx_id = "{}_tx".format(self.id)
+        link_rx = "-chardev socket,path={},id={},server,nowait".format(self.__link_rx, rx_id)
+        link_tx = "-chardev socket,path={},id={},reconnect=10".format(self.__link_tx, tx_id)
+
+        args["link_rx"] = rx_id
+        args["link_tx"] = tx_id
+        if self.__peer_memoryblock:
+            args["peer_memory"] = self.__peer_memoryblock
+
+        opt_list = []
+        opt_list.append("-device skx_ntb")
+        for k, v in args.items():
+            opt_list.append("{}={}".format(k, v))
+
+        self.add_option(link_rx)
+        self.add_option(link_tx)
+        self.add_option(",".join(opt_list))

--- a/infrasim/model/tasks/compute.py
+++ b/infrasim/model/tasks/compute.py
@@ -32,6 +32,7 @@ from infrasim.model.elements.guest_agent import GuestAgent
 from infrasim.model.elements.serial import CSerial
 from infrasim.model.elements.trace import QTrace
 from infrasim.model.elements.ntb import CNTB
+from infrasim.model.elements.dma_engine import CDMAEngine
 
 
 class CCompute(Task, CElement):
@@ -73,6 +74,7 @@ class CCompute(Task, CElement):
         self.__force_shutdown = None
         self.__shm_key = None
         self.__ntb = None
+        self.__dma_engine = None
 
     def enable_sol(self, enabled):
         self.__sol_enabled = enabled
@@ -202,11 +204,6 @@ class CCompute(Task, CElement):
 
         self.__shm_key = self.__compute.get("communicate", {}).get("shm_key")
 
-        self.__ntb = self.__compute.get("ntb")
-        if self.__ntb is not None:
-            ntb_obj = CNTB(self.__ntb)
-            self.__element_list.append(ntb_obj)
-
         machine_obj = CMachine(self.__machine)
         machine_obj.logger = self.logger
         self.__element_list.append(machine_obj)
@@ -253,6 +250,16 @@ class CCompute(Task, CElement):
         backend_network_obj = CBackendNetwork(self.__compute['networks'])
         backend_network_obj.logger = self.logger
         self.__element_list.append(backend_network_obj)
+
+        self.__ntb = self.__compute.get("ntb")
+        if self.__ntb is not None:
+            ntb_obj = CNTB(self.__ntb)
+            self.__element_list.append(ntb_obj)
+
+        self.__dma_engine = self.__compute.get("dma_engine")
+        if self.__dma_engine:
+            dma_engine_obj = CDMAEngine(self.__dma_engine)
+            self.__element_list.append(dma_engine_obj)
 
         if has_option(self.__compute, "ipmi"):
             ipmi_obj = CIPMI(self.__compute['ipmi'])

--- a/infrasim/model/tasks/compute.py
+++ b/infrasim/model/tasks/compute.py
@@ -31,6 +31,7 @@ from infrasim.model.elements.cdrom import IDECdrom
 from infrasim.model.elements.guest_agent import GuestAgent
 from infrasim.model.elements.serial import CSerial
 from infrasim.model.elements.trace import QTrace
+from infrasim.model.elements.ntb import CNTB
 
 
 class CCompute(Task, CElement):
@@ -71,6 +72,7 @@ class CCompute(Task, CElement):
 
         self.__force_shutdown = None
         self.__shm_key = None
+        self.__ntb = None
 
     def enable_sol(self, enabled):
         self.__sol_enabled = enabled
@@ -199,6 +201,11 @@ class CCompute(Task, CElement):
         self.__force_shutdown = self.__compute.get("force_shutdown", True)
 
         self.__shm_key = self.__compute.get("communicate", {}).get("shm_key")
+
+        self.__ntb = self.__compute.get("ntb")
+        if self.__ntb is not None:
+            ntb_obj = CNTB(self.__ntb)
+            self.__element_list.append(ntb_obj)
 
         machine_obj = CMachine(self.__machine)
         machine_obj.logger = self.logger


### PR DESCRIPTION
```
compute:
    ntb:
            bus: bus_80
            addr: '0.0'
            bar1_exp: 15
            bar2_exp: 15
            id: ntb1
            peer_id: ntb0         
            # in chassis, use above 1 value is enough.
            # otherwise should provide 2 values manually.
            # local: /path/to/local/listener
            # peer_rx: /path/to/peer/listener
    dma_engine:
            id: ioat
            addr: '0.0'
            bus: 'bus_82'
```
