### PR TITLE
hotfix: remove wrong configuration render

### DIFF
--- a/test/functional/test_with_bridge.py
+++ b/test/functional/test_with_bridge.py
@@ -225,9 +225,6 @@ class test_bmc_interface_with_bridge(unittest.TestCase):
             "max_drive_per_controller": 6,
             "drives": [{"file": fixtures.image}]
         }]
-        node = model.CNode(self.conf)
-        node.init()
-        self.workspace = node.workspace.get_workspace()
 
     def tearDown(self):
         node = model.CNode(self.conf)


### PR DESCRIPTION
Each test under this class will modify node config then init, no need to render it before the test case (and it will generate a wrong vbmc.conf).