### PR TITLE
set vbmc name and set unlink-close=0 for ipmi_sim cmdline

### DIFF
--- a/infrasim/model/tasks/bmc.py
+++ b/infrasim/model/tasks/bmc.py
@@ -27,6 +27,7 @@ class CBMC(Task):
         super(CBMC, self).__init__()
 
         self.__bmc = bmc_info
+        self.__name = "vbmc"
         self.__address = None
         self.__channel = None
         self.__gem_enable = False
@@ -280,6 +281,7 @@ class CBMC(Task):
             bmc_conf = f.read()
         template = jinja2.Template(bmc_conf)
         bmc_conf = template.render(startcmd_script=self.__startcmd_script,
+                                   vbmc_name=self.__name,
                                    lan_channel=self.__channel,
                                    chassis_control_script=self.__chassiscontrol_script,
                                    lan_control_script=self.__lancontrol_script,
@@ -309,6 +311,7 @@ class CBMC(Task):
     def init(self):
         self.__address = self.__bmc.get('address', 0x20)
         self.__channel = self.__bmc.get('channel', 1)
+        self.__name = self.__bmc.get("name", "vbmc")
         self.__gem_enable = self.__bmc.get("gem_enable", False)
 
         if 'interface' in self.__bmc:

--- a/infrasim/model/tasks/socat.py
+++ b/infrasim/model/tasks/socat.py
@@ -70,7 +70,7 @@ class CSocat(Task):
             os.remove(self.__socket_serial)
 
     def get_commandline(self):
-        socat_str = "{0} pty,link={1},waitslave " \
+        socat_str = "{0} pty,link={1},waitslave,unlink-close=0 " \
             "unix-listen:{2},fork".\
             format(self.__bin, self.__sol_device, self.__socket_serial)
 

--- a/template/vbmc.conf
+++ b/template/vbmc.conf
@@ -5,7 +5,7 @@
 # This is a name used to identify this instance, and used to create
 # the default name of the emulator startup command file and eventually
 # the storage facility for permanent storage.
-name "vbmc"
+name {{vbmc_name}}
 
 #
 # Work on the BMC first


### PR DESCRIPTION
1. enable customized vbmc name and use it as name in syslog
2. set unlink-close to 0 because without "unlink-close=0", the link will be deleted when ipmi_sim is restarted or closed which cause SOL cannot be enabled again.