### PR TITLE
Modify ipmb peer interface usage

### DIFF
--- a/infrasim/model/core/chassis.py
+++ b/infrasim/model/core/chassis.py
@@ -127,7 +127,9 @@ class CChassis(object):
         """
         update smbios and emulation data.
         """
-        data = self.__chassis["data"]
+        data = self.__chassis.get("data", None)
+        if not data:
+            return
         for node in self.__chassis.get("nodes"):
             ws = os.path.join(config.infrasim_home, node["name"])
             ws_data = os.path.join(ws, "data")

--- a/infrasim/model/elements/network.py
+++ b/infrasim/model/elements/network.py
@@ -26,6 +26,7 @@ class CNetwork(CElement):
         self.__index = 0
         self.__bus = None
         self.__addr = None
+        self.__model = None
         self.__multifunction = None
         self.__extra_options = None
 
@@ -69,6 +70,7 @@ class CNetwork(CElement):
         self.__multifunction = self.__network.get('multifunction')
         self.__port_forwards = self.__network.get('port_forward', [])
         self.__extra_options = self.__network.get('extra_option')
+        self.__model = self.__network.get("model")
 
     def handle_parms(self):
         if self.__network_mode == "bridge":
@@ -108,6 +110,10 @@ class CNetwork(CElement):
         if self.__multifunction:
             nic_option = ",".join(["{}".format(nic_option),
                                    "multifunction={}".format(self.__multifunction)])
+        if self.__model:
+            nic_option = ",".join(["{}".format(nic_option),
+                                   "model={}".format(self.__model)])
+
         if self.__extra_options:
             nic_option = ",".join(["{}".format(nic_option), self.__extra_options])
 

--- a/template/vbmc.conf
+++ b/template/vbmc.conf
@@ -12,7 +12,9 @@ name "{{vbmc_name}}"
 set_working_mc 0x20
 
   # Define a LAN channel
+  {% for lan_channel in lan_channels %}
   startlan {{lan_channel}}
+  {% if lan_channel == main_channel %}
     # Define an IP address and port to listen on.  You can define more
     # than one address/port to listen on multiple addresses.  The ::
     # listens on all addresses.
@@ -37,7 +39,9 @@ set_working_mc 0x20
 
     # A program to get and set the LAN configuration of the interface.
     {% if intf_not_exists %}#{% endif %} lan_config_program "{{lan_control_script}} {{lan_interface}}"
+  {% endif %}
   endlan
+  {% endfor %}
 
   chassis_control "{{chassis_control_script}} 0x20"
 
@@ -86,7 +90,7 @@ set_working_mc 0x20
   {% if peers %}
   {% for peer in peers %}
   # peer BMC({{peer.addr}}) information
-  peer {{peer.addr}} {{peer.interface}} {{peer.user}} {{peer.password}} {{peer.host}}
+  ipmb {{vbmc_addr}} 0.0.0.0 {{port_ipmb}} peer {{peer.addr}} {{peer.host}} {{peer.port_ipmb}}
   {% endfor %}
   {% endif %}
   {% if sol_enabled %}

--- a/test/functional/test_bmc_peer_communication.py
+++ b/test/functional/test_bmc_peer_communication.py
@@ -138,18 +138,20 @@ class test_bmc_communication(unittest.TestCase):
         fake_node["bmc"] = {}
         fake_node["bmc"]["peer-bmcs"] = [
             {
-                "interface": "lanplus",
-                "user": "admin",
-                "password": "admin"
+                "port_ipmb": 9009
             }
         ]
 
         if node_name == "test0":
+            fake_node["bmc"]["address"] = 0x1c
             fake_node["bmc"]["peer-bmcs"][0]["addr"] = 0x1e
             fake_node["bmc"]["peer-bmcs"][0]["host"] = "192.168.188.92"
+            fake_node["bmc"]["peer-bmcs"][0]["port_ipmb"] = 9009
         else:
+            fake_node["bmc"]["address"] = 0x1e
             fake_node["bmc"]["peer-bmcs"][0]["addr"] = 0x1c
             fake_node["bmc"]["peer-bmcs"][0]["host"] = "192.168.188.91"
+            fake_node["bmc"]["peer-bmcs"][0]["port_ipmb"] = 9009
 
         fake_node_up = test_bmc_communication._start_node(fake_node, node_name, node_type)
         return fake_node_up


### PR DESCRIPTION
1. According to new ipmb peer connection in openipmi implementation, we don't need <user> <password> <interface> in vbmc.conf, so we remove them in infrasim-compute.
2. Support multiple lan channels in bmc config

example yml:
```
bmc:
  address: 32
  channels: 1,4
  main_channel: 4
  peer-bmcs:
  - addr: 30
    host: xx.xx.xx.xx
    port_ipmb: 9009
  port_ipmb: 9009
```