### PR TITLE
hot fix in ssh

### DIFF
--- a/infrasim/helper.py
+++ b/infrasim/helper.py
@@ -693,7 +693,7 @@ def prepare_ssh(ip_addr="127.0.0.1", port=2222, username="root", password="root"
 
 
 def ssh_exec(ssh, cmd):
-    _, stdout, _ = ssh.exec_command(cmd, get_pty=True)
+    _, stdout, _ = ssh.exec_command(cmd)
     return stdout.read()
 
 

--- a/test/functional/test_drive_error_inject.py
+++ b/test/functional/test_drive_error_inject.py
@@ -133,7 +133,8 @@ class test_error_inject(unittest.TestCase):
                 }
             }
         }
-        cmd = "nvme read {} -z 3008 -a 128".format(dev)
+        # Redirect stderr to stdout since 'Success' is printed to stderr sometimes"
+        cmd = "nvme read {} -z 3008 -a 128 2>&1".format(dev)
 
         for cmd_error_inject in error_inject_list:
             payload_error_inject['arguments']['status_field']['sc'] = cmd_error_inject[0]

--- a/test/functional/test_sas.py
+++ b/test/functional/test_sas.py
@@ -359,7 +359,6 @@ class test_disk_array_topo(unittest.TestCase):
                 self.assertIn("Unit serial number: ZABC", rst, "Serial Number not as expected:\n"
                               "{}".format(rst))
 
-    @unittest.skipIf(os.environ.get('SKIP_TESTS'), "SKIP Test for PR Triggered Tests, Known issue: IN-1619")
     def test_scsi_devices_availability(self):
         # Verify all devices can be found by OS.
         rst = run_cmd("lspci")
@@ -392,7 +391,6 @@ class test_disk_array_topo(unittest.TestCase):
             for key, val in expect.iteritems():
                 self.assertEqual(val, 1, "SCSI Device count error in sys: {0} count={1}".format(key, val))
 
-    @unittest.skipIf(os.environ.get('SKIP_TESTS'), "SKIP Test for PR Triggered Tests, Known issue: IN-1619")
     def test_sas_chain(self):
         # Verify the connection between expanders
         topology = {}
@@ -458,16 +456,13 @@ class test_disk_array_topo(unittest.TestCase):
         verify_link(wwn_exp1, 4, wwn_exp3, 0, 4)
 
 
-@unittest.skipIf(os.environ.get('SKIP_TESTS'), "SKIP Test for PR Triggered Tests, Known issue: IN-1619")
 class test_disk_directly(unittest.TestCase):
 
     @classmethod
-    @unittest.skipIf(os.environ.get('SKIP_TESTS'), "SKIP Test for PR Triggered Tests, Known issue: IN-1619")
     def setUpClass(cls):
         start_node(get_node_directly())
 
     @classmethod
-    @unittest.skipIf(os.environ.get('SKIP_TESTS'), "SKIP Test for PR Triggered Tests, Known issue: IN-1619")
     def tearDownClass(cls):
         stop_node()
 


### PR DESCRIPTION
1. remove '@unittest.skip' instruction since the issue has gone
2. test: nvme redirect stderr to stdout
3. paramiko: remove get_pty attributes since it hangs when there is '*' in command
