### PR TITLE
Add nvram file customized configuration, skip some peer bmc cases in pr test

### DIFF
--- a/infrasim/model/tasks/bmc.py
+++ b/infrasim/model/tasks/bmc.py
@@ -130,10 +130,6 @@ class CBMC(Task):
             raise ArgsNotCorrect("[BMC] workspace  {} doesn\'t exist".
                                  format(self.__workspace))
 
-        # check nvram binary file exists if gem_enable
-        if self.__gem_enable and not os.path.isfile(os.path.join(self.get_workspace(), "data/nvram.bin")):
-            raise ArgsNotCorrect("[BMC] gem is enable but nvram doesn\'t exist")
-
         # check if main channel is included in all lan channels
         if self.__main_channel not in self.__channels:
             raise ArgsNotCorrect("[BMC] main channel {} should be included in channels {}".

--- a/infrasim/model/tasks/bmc.py
+++ b/infrasim/model/tasks/bmc.py
@@ -43,6 +43,7 @@ class CBMC(Task):
         self.__password = None
         self.__emu_file = None
         self.__config_file = ""
+        self.__nvram_file = None
         self.__bin = "ipmi_sim"
         self.__port_iol = None
         self.__ipmi_listen_range = "::"
@@ -112,7 +113,7 @@ class CBMC(Task):
         if not os.path.isfile(self.__emu_file):
             raise ArgsNotCorrect("[BMC] Target emulation file doesn't exist: {}".
                                  format(self.__emu_file))
-        # check script exits
+        # check script exists
         if not os.path.exists(self.__lancontrol_script):
             raise ArgsNotCorrect("[BMC] Lan control script {} doesn\'t exist".
                                  format(self.__lancontrol_script))
@@ -129,6 +130,11 @@ class CBMC(Task):
             raise ArgsNotCorrect("[BMC] workspace  {} doesn\'t exist".
                                  format(self.__workspace))
 
+        # check nvram binary file exists if gem_enable
+        if self.__gem_enable and not os.path.isfile(os.path.join(self.get_workspace(), "data/nvram.bin")):
+            raise ArgsNotCorrect("[BMC] gem is enable but nvram doesn\'t exist")
+
+        # check if main channel is included in all lan channels
         if self.__main_channel not in self.__channels:
             raise ArgsNotCorrect("[BMC] main channel {} should be included in channels {}".
                                  format(self.__main_channel, self.__channels))
@@ -401,6 +407,12 @@ class CBMC(Task):
             self.write_bmc_config(os.path.join(self.get_workspace(), "etc/vbmc.conf"))
         else:
             raise ArgsNotCorrect("[BMC] Couldn't find vbmc.conf")
+
+        if 'nvram_file' in self.__bmc:
+            self.__nvram_file = self.__bmc['nvram_file']
+            if os.path.exists(self.__nvram_file):
+                shutil.copy(self.__nvram_file,
+                            os.path.join(self.get_workspace(), "data/nvram.bin"))
 
         if 'shm_key' in self.__bmc:
             self.__shm_key = self.__bmc['shm_key']

--- a/test/functional/test_bmc_peer_communication.py
+++ b/test/functional/test_bmc_peer_communication.py
@@ -83,6 +83,7 @@ def teardown_module():
     os.environ['PATH'] = old_path
 
 
+@unittest.skipIf(os.environ.get('SKIP_TESTS'), "SKIP Test for PR Triggered Tests")
 class test_bmc_communication(unittest.TestCase):
 
     @classmethod

--- a/test/functional/test_configuration_change.py
+++ b/test/functional/test_configuration_change.py
@@ -266,7 +266,7 @@ class test_bmc_configuration_change(unittest.TestCase):
 
     def test_set_bmc_lan_channel(self):
         self.conf["bmc"] = {}
-        self.conf["bmc"]["channel"] = 3
+        self.conf["bmc"]["main_channel"] = 3
 
         node = model.CNode(self.conf)
         node.init()
@@ -278,7 +278,7 @@ class test_bmc_configuration_change(unittest.TestCase):
 
         cmd = 'ipmitool -H 127.0.0.1 -U admin -P admin -I lanplus lan print {}'
 
-        assert run_command(cmd.format(self.conf["bmc"]["channel"]),
+        assert run_command(cmd.format(self.conf["bmc"]["main_channel"]),
                            stdout=subprocess.PIPE,
                            stderr=subprocess.PIPE)[0] == 0
 


### PR DESCRIPTION
1. Add section to let user pass nvram_file in yml.
2. Skip test cases that are sent through lan/lanplus channel in peer bmc functional test, waiting for the feature to be supported.