### PR TITLE
smbios: add support to modify Processor, memory device information

### DIFF
--- a/infrasim/chassis/smbios.py
+++ b/infrasim/chassis/smbios.py
@@ -203,7 +203,7 @@ class SMBios(object):
             if isinstance(__uuid, uuid.UUID):
                 __data = __uuid.bytes_le
             if __data is None:
-                raise Exception("Unrecgnized uuid format in type1")
+                raise Exception("Unrecognized uuid format in type1")
             info[7] = __data
 
         # modify SKU number

--- a/infrasim/chassis/smbios.py
+++ b/infrasim/chassis/smbios.py
@@ -213,6 +213,8 @@ class SMBios(object):
         string_offset = struct.calcsize(board_info_fmt) + info[12] * 2
         # split string content
         string_values = board_info[string_offset:].split('\0')
+        # Modify SN
+        info[6] = self.__update_string(string_values, info[6], info_map.get('sn'))
         # Modify string of Location in Chassis
         location_index = info[9]
         info[9] = self.__update_string(string_values, location_index, info_map.get('location'))

--- a/infrasim/chassis/smbios.py
+++ b/infrasim/chassis/smbios.py
@@ -325,47 +325,51 @@ class SMBios(object):
             # don't modify memory device array.
             return
 
-        fields = [
-            "type",
-            "length",
-            "handle",
-            "physical memory array handle",
-            "memory error information handle",
-            "total width",
-            "data width",
-            "size",
-            "form factor",
-            "device set",
-            "device locator",
-            "ban locator",
-            "memory type",
-            "type detail",
-            "speed",
-            "manufactuer",
-            "sn",
-            "asset tag",
-            "part number",
-            "attributes",
-            "extended size",
-            "configured memory clock speed",
-            "min volt",
-            "max volt",
-            "config volt"]
+        class mem_dev_struct(list):
+            fields = [
+                "type",
+                "length",
+                "handle",
+                "physical memory array handle",
+                "memory error information handle",
+                "total width",
+                "data width",
+                "size",
+                "form factor",
+                "device set",
+                "device locator",
+                "ban locator",
+                "memory type",
+                "type detail",
+                "speed",
+                "manufactuer",
+                "sn",
+                "asset tag",
+                "part number",
+                "attributes",
+                "extended size",
+                "configured memory clock speed",
+                "min volt",
+                "max volt",
+                "config volt"]
 
-        def I(t):
-            return fields.index(t)
+            def __setitem__(self, key, value):
+                super(mem_dev_struct, self).__setitem__(self.fields.index(key), value)
+
+            def __getitem__(self, key):
+                return super(mem_dev_struct, self).__getitem__(self.fields.index(key))
 
         dim_position_reg = re.compile(r'DIMM (\d+)')
 
         for idx in self.__type17_index_list:
             mem_info = self.__dict[idx]
-            info = list(struct.unpack_from(mem_info_fmt, mem_info))
+            info = mem_dev_struct(struct.unpack_from(mem_info_fmt, mem_info))
             offset = struct.calcsize(mem_info_fmt)
             string_values = mem_info[offset:].split('\0')
 
             # found memory device by device locator
             # since the memory device array is not ordered.
-            dev_locator = string_values[info[I("device locator") - 1]]
+            dev_locator = string_values[info["device locator"] - 1]
             m = dim_position_reg.match(dev_locator)
             if m:
                 position = int(m.group(1))
@@ -380,54 +384,54 @@ class SMBios(object):
 
             # modify memory device by dimm_info
             if dimm_info.get('size', 0) == 0:
-                info[I("total width")] = 0
-                info[I("data width")] = 0
-                info[I("size")] = 0
-                info[I("form factor")] = 2
-                info[I("device set")] = 0
-                info[I("device locator")] = 1
-                info[I("ban locator")] = 2
-                info[I("memory type")] = 2
-                info[I("type detail")] = 0
-                info[I("speed")] = 0
-                info[I("attributes")] = 0
-                info[I("extended size")] = 0
-                info[I("configured memory clock speed")] = 0
+                info["total width"] = 0
+                info["data width"] = 0
+                info["size"] = 0
+                info["form factor"] = 2
+                info["device set"] = 0
+                info["device locator"] = 1
+                info["ban locator"] = 2
+                info["memory type"] = 2
+                info["type detail"] = 0
+                info["speed"] = 0
+                info["attributes"] = 0
+                info["extended size"] = 0
+                info["configured memory clock speed"] = 0
 
-                info[I("manufactuer")] = self.__update_string(string_values, info[I("manufactuer")], "NO DIMM")
-                info[I("sn")] = self.__update_string(string_values, info[I("sn")], "NO DIMM")
-                info[I("asset tag")] = self.__update_string(string_values, info[I("asset tag")], "NO DIMM")
-                info[I("part number")] = self.__update_string(string_values, info[I("part number")], "NO DIMM")
+                info["manufactuer"] = self.__update_string(string_values, info["manufactuer"], "NO DIMM")
+                info["sn"] = self.__update_string(string_values, info["sn"], "NO DIMM")
+                info["asset tag"] = self.__update_string(string_values, info["asset tag"], "NO DIMM")
+                info["part number"] = self.__update_string(string_values, info["part number"], "NO DIMM")
             else:
-                info[I("total width")] = 72
-                info[I("data width")] = 64
+                info["total width"] = 72
+                info["data width"] = 64
                 size = dimm_info.get('size')
                 # according to spec,
                 # info['size'] & 0x8000 == 1, unit = KB.
                 # info['size'] & 0x8000 == 0, unit = MB.
                 if size < 1024 * 1024:
                     size = size / 1024
-                    info[I("size")] = 0x8000 + size
+                    info["size"] = 0x8000 + size
                 else:
                     size = size / 1024 / 1024
-                    info[I("size")] = size
-                info[I("form factor")] = 9
-                info[I("device set")] = 0
-                info[I("device locator")] = 1
-                info[I("ban locator")] = 2
-                info[I("memory type")] = 26
-                info[I("type detail")] = 128
-                info[I("speed")] = 2666
-                info[I("attributes")] = 2
-                info[I("extended size")] = 0
-                info[I("configured memory clock speed")] = 2666
-                info[I("manufactuer")] = self.__update_string(string_values, info[I("manufactuer")],
-                                                              dimm_info.get('manufactuer', 'Hynix'))
-                info[I("sn")] = self.__update_string(string_values, info[I("sn")], dimm_info.get('sn'))
-                info[I("asset tag")] = self.__update_string(string_values, info[I("asset tag")],
-                                                            dimm_info.get('asset_tag', string_values[0] + '_AssetTag'))
-                info[I("part number")] = self.__update_string(string_values, info[I("part number")],
-                                                              dimm_info.get('part_number', 'HMA82GR7AFR8N-VK'))
+                    info["size"] = size
+                info["form factor"] = 9
+                info["device set"] = 0
+                info["device locator"] = 1
+                info["ban locator"] = 2
+                info["memory type"] = 26
+                info["type detail"] = 128
+                info["speed"] = 2666
+                info["attributes"] = 2
+                info["extended size"] = 0
+                info["configured memory clock speed"] = 2666
+                info["manufactuer"] = self.__update_string(string_values, info["manufactuer"],
+                                                           dimm_info.get('manufactuer', 'Hynix'))
+                info["sn"] = self.__update_string(string_values, info["sn"], dimm_info.get('sn'))
+                info["asset tag"] = self.__update_string(string_values, info["asset tag"],
+                                                         dimm_info.get('asset_tag', string_values[0] + '_AssetTag'))
+                info["part number"] = self.__update_string(string_values, info["part number"],
+                                                           dimm_info.get('part_number', 'HMA82GR7AFR8N-VK'))
 
             # pack modified data and save it
             result = struct.pack(mem_info_fmt, *info)

--- a/infrasim/chassis/smbios.py
+++ b/infrasim/chassis/smbios.py
@@ -164,8 +164,9 @@ class SMBios(object):
         if value is None:
             return index
         if index <= 0:
-            string_values.append(value)
-            index = len(string_values)
+            index = len(string_values) - 2
+            string_values.insert(index, value)
+            index += 1
         else:
             string_values[index - 1] = value
         return index
@@ -186,7 +187,6 @@ class SMBios(object):
         offset = struct.calcsize(sys_info_fmt)
         # split content
         string_values = sys_info[offset:].split('\0')
-
         # modify SN string.
         info[6] = self.__update_string(string_values, info[6], info_map.get('sn'))
 
@@ -213,6 +213,7 @@ class SMBios(object):
         string_offset = struct.calcsize(board_info_fmt) + info[12] * 2
         # split string content
         string_values = board_info[string_offset:].split('\0')
+
         # Modify SN
         info[6] = self.__update_string(string_values, info[6], info_map.get('sn'))
         # Modify string of Location in Chassis
@@ -460,10 +461,8 @@ class SMBios(object):
         # update checksum
         entry[SMBios.Id_Checksum2] = 0
         entry[SMBios.Id_Checksum] = 0
-
-        entry[SMBios.Id_Checksum2] = self.__get_checksum(struct.pack(SMBios._fmt_entry, *entry)[0x10:0xf])
+        entry[SMBios.Id_Checksum2] = self.__get_checksum(struct.pack(SMBios._fmt_entry, *entry)[0x10:0x1f])
         entry[SMBios.Id_Checksum] = self.__get_checksum(struct.pack(SMBios._fmt_entry, *entry))
-
         # write file.
         with open(dst, "wb") as fo:
             fo.write(struct.pack(SMBios._fmt_entry, *entry))

--- a/infrasim/chassis/smbios.py
+++ b/infrasim/chassis/smbios.py
@@ -4,6 +4,7 @@ Copyright @ 2018 Dell EMC Corporation All Rights Reserved
 *********************************************************
 '''
 import struct
+import re
 
 
 class SMBios(object):
@@ -39,6 +40,7 @@ class SMBios(object):
     '''
     _fmt_entry = "4sBBBBHb5s5sBHIHBB"
     '''
+    spec filename: DSP0134_3.0.0.pdf
     Entry Format 3.0. Ref to SMBios SPEC Ver:3.0.0, Chapter:5.2.2
     struct SMBIOSEntryPoint {
      char EntryPointString[5];    //This is '_SM3_'
@@ -64,6 +66,9 @@ class SMBios(object):
     TYPE_SystemInformation = 1
     TYPE_BaseboardInformation = 2
     TYPE_ChassisInformation = 3
+    TYPE_ProcessorInformation = 4
+    TYPE_PhysicalMemoryArrayInformation = 16
+    TYPE_MemoryDevice = 17
 
     def __init__(self, src):
         '''
@@ -73,6 +78,9 @@ class SMBios(object):
         self.__entry = None
         self.__type1_index = None
         self.__type3_index = None
+        self.__type4_index_list = []
+        self.__type16_index_list = []
+        self.__type17_index_list = []
         self.save = None
         with open(src, "rb") as fin:
             self._buf = fin.read()
@@ -89,22 +97,7 @@ class SMBios(object):
         # get offset from header['TableAddress'].
         offset = entry[9]
         while offset < len(self._buf):
-            header = struct.unpack_from(SMBios._fmt_header, self._buf, offset)
-            start = offset
-            offset += header[1]
-            while self._buf[offset] != '\0' or self._buf[offset + 1] != '\0':
-                offset += 1
-            offset += 2
-            structure = self._buf[start:offset]
-
-            if header[0] == SMBios.TYPE_SystemInformation:  # mark the system information structure.
-                self.__type1_index = len(self.__dict)
-            if header[0] == SMBios.TYPE_ChassisInformation:
-                self.__type3_index = len(self.__dict)
-            if header[0] == SMBios.TYPE_BaseboardInformation:
-                self.__type2_index = len(self.__dict)
-
-            self.__dict.append(structure)
+            offset = self.__decode_entry(offset)
         return True
 
     def __save3(self, dst):
@@ -139,25 +132,49 @@ class SMBios(object):
         self.__entry = entry
         offset = struct.calcsize(SMBios._fmt_entry)
         for _ in range(0, entry[12]):
-            header = struct.unpack_from(SMBios._fmt_header, self._buf, offset)
-            start = offset
-            offset += header[1]
-            while self._buf[offset] != '\0' or self._buf[offset + 1] != '\0':
-                offset += 1
-            offset += 2
-            structure = self._buf[start:offset]
-
-            if header[0] == SMBios.TYPE_SystemInformation:  # mark the system information structure.
-                self.__type1_index = len(self.__dict)
-            if header[0] == SMBios.TYPE_ChassisInformation:
-                self.__type3_index = len(self.__dict)
-            if header[0] == SMBios.TYPE_BaseboardInformation:
-                self.__type2_index = len(self.__dict)
-
-            self.__dict.append(structure)
+            offset = self.__decode_entry(offset)
         return True
 
-    def ModifyType1SystemInformation(self, sn):
+    def __decode_entry(self, offset):
+        header = struct.unpack_from(SMBios._fmt_header, self._buf, offset)
+        start = offset
+        offset += header[1]
+        while self._buf[offset] != '\0' or self._buf[offset + 1] != '\0':
+            offset += 1
+        offset += 2
+        structure = self._buf[start:offset]
+
+        if header[0] == SMBios.TYPE_SystemInformation:  # mark the system information structure.
+            self.__type1_index = len(self.__dict)
+        if header[0] == SMBios.TYPE_ChassisInformation:
+            self.__type3_index = len(self.__dict)
+        if header[0] == SMBios.TYPE_BaseboardInformation:
+            self.__type2_index = len(self.__dict)
+        if header[0] == SMBios.TYPE_ProcessorInformation:
+            self.__type4_index_list.append(len(self.__dict))
+        if header[0] == SMBios.TYPE_PhysicalMemoryArrayInformation:
+            self.__type16_index_list.append(len(self.__dict))
+        if header[0] == SMBios.TYPE_MemoryDevice:
+            self.__type17_index_list.append(len(self.__dict))
+
+        self.__dict.append(structure)
+        return offset
+
+    def __update_string(self, string_values, index, value):
+        if value is None:
+            return index
+        if index <= 0:
+            string_values.append(value)
+            index = len(string_values)
+        else:
+            string_values[index - 1] = value
+        return index
+
+    def ModifyType1SystemInformation(self, info_map):
+        '''
+        support following fields,
+        sn, uuid, and sku_number,
+        '''
         if self.__type1_index is None:
             return
         # Refer to Chapter 7.2
@@ -165,41 +182,40 @@ class SMBios(object):
         # fetch the System Information Structure
         sys_info = self.__dict[self.__type1_index]
         # __decode header.
-        info = struct.unpack_from(sys_info_fmt, sys_info)
+        info = list(struct.unpack_from(sys_info_fmt, sys_info))
         offset = struct.calcsize(sys_info_fmt)
         # split content
         string_values = sys_info[offset:].split('\0')
 
         # modify SN string.
-        sn_index = info[6]  # position number of SN.
-        if sn_index > 0:
-            string_values[sn_index - 1] = sn
-        else:
-            info[6] = len(string_values) + 1
-            string_values.append(sn)
+        info[6] = self.__update_string(string_values, info[6], info_map.get('sn'))
+
+        # modify uuid
+        if 'uuid'in info_map and len(info_map['uuid']) == 16:
+            info[7] = info_map['uuid']
+
+        # modify SKU number
+        sku_index = info[9]
+        info[9] = self.__update_string(string_values, sku_index, info_map.get('sku_number'))
 
         # pack modified data and save it
         result = struct.pack(sys_info_fmt, *info)
         result += '\0'.join(string_values)
         self.__dict[self.__type1_index] = result
 
-    def ModifyType2BaseboardInformation(self, location):
+    def ModifyType2BaseboardInformation(self, info_map):
         if self.__type2_index is None:
             return
         # Ref to SMBios SPEC Ver: 2.7.1, Chapter 7.3
         board_info_fmt = "=BBHBBBBBBBHBB"
         board_info = self.__dict[self.__type2_index]
-        info = struct.unpack_from(board_info_fmt, board_info)
+        info = list(struct.unpack_from(board_info_fmt, board_info))
         string_offset = struct.calcsize(board_info_fmt) + info[12] * 2
         # split string content
         string_values = board_info[string_offset:].split('\0')
         # Modify string of Location in Chassis
         location_index = info[9]
-        if location_index > 0:
-            string_values[location_index - 1] = location
-        else:
-            info[9] = len(string_values) + 1
-            string_values.append(location)
+        info[9] = self.__update_string(string_values, location_index, info_map.get('location'))
 
         # pack modified data and save it
         result = struct.pack(board_info_fmt, *info)
@@ -208,7 +224,11 @@ class SMBios(object):
 
         self.__dict[self.__type2_index] = result
 
-    def ModifyType3ChassisInformation(self, sn):
+    def ModifyType3ChassisInformation(self, info_map):
+        '''
+        support following fields,
+        sn,
+        '''
         if self.__type3_index is None:
             return
         # Ref to SMBios SPEC Ver: 2.7.1, Chapter 7.4
@@ -217,7 +237,7 @@ class SMBios(object):
         # fetch the System Information Structure
         chassis_info = self.__dict[self.__type3_index]
         # decode header.
-        info = struct.unpack_from(chassis_info_fmt, chassis_info)
+        info = list(struct.unpack_from(chassis_info_fmt, chassis_info))
         # skip Contained elements start at 0x15h.
         offset = struct.calcsize(chassis_info_fmt) + info[15] * info[16] + 1
         # split string content
@@ -225,11 +245,7 @@ class SMBios(object):
 
         # modify SN string.
         sn_index = info[6]  # position number of SN.
-        if sn_index > 0:
-            string_values[sn_index - 1] = sn
-        else:
-            info[6] = len(string_values) + 1
-            string_values.append(sn)
+        info[6] = self.__update_string(string_values, sn_index, info_map.get('sn'))
 
         # pack modified data and save it
         result = struct.pack(chassis_info_fmt, *info)
@@ -237,6 +253,187 @@ class SMBios(object):
         result += '\0'.join(string_values)
 
         self.__dict[self.__type3_index] = result
+
+    def ModifyType4ProcessorInformation(self, cpu):
+        '''
+        support following fields,
+        sn, version, core number, speed, max speed, part number and asset tag.
+        '''
+        if len(self.__type4_index_list) == 0:
+            return
+        # Format of Processor Information (Type 4). Ref Chapter 7.5
+        pro_info_fmt = '=BBHBBBBQBBHHHBBHHHBBBBBBHHHHH'
+        for idx in self.__type4_index_list:
+            info = self.__dict[idx]
+            pro_info = list(struct.unpack_from(pro_info_fmt, info))
+            offset = struct.calcsize(pro_info_fmt)
+            string_values = info[offset:].split('\0')
+
+            # pro_info[7] = 0 # process ID
+            # update Processor Version
+            pro_info[8] = self.__update_string(string_values, pro_info[8], cpu.get("version"))
+            pro_info[11] = cpu.get('max_speed', 4000)  # max spped. MHz
+            pro_info[12] = cpu.get('speed', 1800)  # current speed. MHz
+
+            # update sn
+            pro_info[18] = self.__update_string(string_values, pro_info[18], cpu.get('sn'))
+            # update asset tag
+            pro_info[19] = self.__update_string(string_values, pro_info[19], cpu.get('asset_tag'))
+            # update part number
+            pro_info[20] = self.__update_string(string_values, pro_info[20], cpu.get('part_number'))
+
+            core_number = cpu.get("cores", 4)
+            pro_info[21] = core_number  # Core Count
+            pro_info[22] = core_number  # Core Enabled
+            pro_info[23] = core_number  # Thread Count
+            # Core count 2, Core Enabled 2 and Thread Count 2 set to same value if core count < 255.
+            pro_info[26] = core_number  # Core Count 2.
+            pro_info[27] = core_number  # Core Enabled 2
+            pro_info[28] = core_number  # Thread Count 2
+
+            # pack modified data and save it
+            result = struct.pack(pro_info_fmt, *pro_info)
+            result += '\0'.join(string_values)
+            self.__dict[idx] = result
+
+    def CheckType16PhysicalMemoryArray(self, total_count):
+        if len(self.__type16_index_list) == 0:
+            raise Exception("Type 16 - Physical Memory Array is missing")
+        fmt = '=BBHBBBIHHQ'
+        count = 0
+        for idx in self.__type16_index_list:
+            raw = self.__dict[idx]
+            info = struct.unpack_from(fmt, raw)
+            # support there is 24 memory slots on board.
+            # if not, Slot number in Type16 Physical Memory Array must be modified.
+            # 8th field "Number of Memory Devices"
+            count += info[8]
+        if count < total_count:
+            raise Exception('Not enough dimm slots. Provides: {}, expected: {}'.format(count, total_count))
+
+    def ModifyType17MemoryDevice(self, dimm=None):
+        '''
+        support following fields,
+        sn, size, part number, manufactuer, asset tag, part number and number of dimm
+        '''
+        self.CheckType16PhysicalMemoryArray(len(dimm))
+        if len(self.__type4_index_list) == 0:
+            raise Exception("Type 17 - Memory Device is missing")
+
+        mem_info_fmt = '=BBHHHHHHBBBBBHHBBBBBIHHHH'
+        if dimm is None:
+            # don't modify memory device array.
+            return
+
+        fields = [
+            "type",
+            "length",
+            "handle",
+            "physical memory array handle",
+            "memory error information handle",
+            "total width",
+            "data width",
+            "size",
+            "form factor",
+            "device set",
+            "device locator",
+            "ban locator",
+            "memory type",
+            "type detail",
+            "speed",
+            "manufactuer",
+            "sn",
+            "asset tag",
+            "part number",
+            "attributes",
+            "extended size",
+            "configured memory clock speed",
+            "min volt",
+            "max volt",
+            "config volt"]
+
+        def I(t):
+            return fields.index(t)
+
+        dim_position_reg = re.compile(r'DIMM (\d+)')
+
+        for idx in self.__type17_index_list:
+            mem_info = self.__dict[idx]
+            info = list(struct.unpack_from(mem_info_fmt, mem_info))
+            offset = struct.calcsize(mem_info_fmt)
+            string_values = mem_info[offset:].split('\0')
+
+            # found memory device by device locator
+            # since the memory device array is not ordered.
+            dev_locator = string_values[info[I("device locator") - 1]]
+            m = dim_position_reg.match(dev_locator)
+            if m:
+                position = int(m.group(1))
+            else:
+                raise Exception('Can not found positon of memory device {0}'.format(dev_locator))
+            # get expected dimm information.
+            if position < len(dimm):
+                dimm_info = dimm[position]
+            else:
+                # no dimm information.
+                dimm_info = {}
+
+            # modify memory device by dimm_info
+            if dimm_info.get('size', 0) == 0:
+                info[I("total width")] = 0
+                info[I("data width")] = 0
+                info[I("size")] = 0
+                info[I("form factor")] = 2
+                info[I("device set")] = 0
+                info[I("device locator")] = 1
+                info[I("ban locator")] = 2
+                info[I("memory type")] = 2
+                info[I("type detail")] = 0
+                info[I("speed")] = 0
+                info[I("attributes")] = 0
+                info[I("extended size")] = 0
+                info[I("configured memory clock speed")] = 0
+
+                info[I("manufactuer")] = self.__update_string(string_values, info[I("manufactuer")], "NO DIMM")
+                info[I("sn")] = self.__update_string(string_values, info[I("sn")], "NO DIMM")
+                info[I("asset tag")] = self.__update_string(string_values, info[I("asset tag")], "NO DIMM")
+                info[I("part number")] = self.__update_string(string_values, info[I("part number")], "NO DIMM")
+            else:
+                info[I("total width")] = 72
+                info[I("data width")] = 64
+                size = dimm_info.get('size')
+                # according to spec,
+                # info['size'] & 0x8000 == 1, unit = KB.
+                # info['size'] & 0x8000 == 0, unit = MB.
+                if size < 1024 * 1024:
+                    size = size / 1024
+                    info[I("size")] = 0x8000 + size
+                else:
+                    size = size / 1024 / 1024
+                    info[I("size")] = size
+                info[I("form factor")] = 9
+                info[I("device set")] = 0
+                info[I("device locator")] = 1
+                info[I("ban locator")] = 2
+                info[I("memory type")] = 26
+                info[I("type detail")] = 128
+                info[I("speed")] = 2666
+                info[I("attributes")] = 2
+                info[I("extended size")] = 0
+                info[I("configured memory clock speed")] = 2666
+                info[I("manufactuer")] = self.__update_string(string_values, info[I("manufactuer")],
+                                                              dimm_info.get('manufactuer', 'Hynix'))
+                info[I("sn")] = self.__update_string(string_values, info[I("sn")], dimm_info.get('sn'))
+                info[I("asset tag")] = self.__update_string(string_values, info[I("asset tag")],
+                                                            dimm_info.get('asset_tag', string_values[0] + '_AssetTag'))
+                info[I("part number")] = self.__update_string(string_values, info[I("part number")],
+                                                              dimm_info.get('part_number', 'HMA82GR7AFR8N-VK'))
+
+            # pack modified data and save it
+            result = struct.pack(mem_info_fmt, *info)
+            result += '\0'.join(string_values)
+
+            self.__dict[idx] = result
 
     def __get_checksum(self, buf):
         check_sum = sum(bytearray(buf))

--- a/infrasim/chassis/smbios.py
+++ b/infrasim/chassis/smbios.py
@@ -5,6 +5,7 @@ Copyright @ 2018 Dell EMC Corporation All Rights Reserved
 '''
 import struct
 import re
+import uuid
 
 
 class SMBios(object):
@@ -191,8 +192,19 @@ class SMBios(object):
         info[6] = self.__update_string(string_values, info[6], info_map.get('sn'))
 
         # modify uuid
-        if 'uuid'in info_map and len(info_map['uuid']) == 16:
-            info[7] = info_map['uuid']
+        __uuid = info_map.get('uuid')
+        if __uuid:
+            __data = None
+            if isinstance(__uuid, str):
+                if len(__uuid) == 16:
+                    __data = __uuid
+                if len(__uuid) == 36:
+                    __uuid = uuid.UUID("{" + __uuid + "}")
+            if isinstance(__uuid, uuid.UUID):
+                __data = __uuid.bytes_le
+            if __data is None:
+                raise Exception("Unrecgnized uuid format in type1")
+            info[7] = __data
 
         # modify SKU number
         sku_index = info[9]

--- a/infrasim/model/core/chassis.py
+++ b/infrasim/model/core/chassis.py
@@ -144,7 +144,7 @@ class CChassis(object):
                 return dst
             bios_file = get_file(node["compute"].get("smbios"), "{}_smbios.bin".format(node["type"]))
             bios = SMBios(bios_file)
-            bios.ModifyType3ChassisInformation(data["sn"])
+            bios.ModifyType3ChassisInformation({'sn': data["sn"]})
             # bios.ModifyType2BaseboardInformation("")
             bios.save(bios_file)
 

--- a/infrasim/model/tasks/compute.py
+++ b/infrasim/model/tasks/compute.py
@@ -187,7 +187,7 @@ class CCompute(Task, CElement):
         if 'serial_number' in self.__compute and os.path.exists(self.__smbios):
             self.__serial_number = self.__compute['serial_number']
             bios = SMBios(self.__smbios)
-            bios.ModifyType1SystemInformation(self.__serial_number)
+            bios.ModifyType1SystemInformation({'sn': self.__serial_number})
             bios.save(self.__smbios)
 
         self.__bios = self.__compute.get('bios')


### PR DESCRIPTION
usage of smbios.py
```
def test_smbios(filename):
    bios = SMBios(filename)
    chassis_info = {"sn": "hahahaha"}
    bios.ModifyType3ChassisInformation(chassis_info)

    type2_info = {"sn": "whatever", "location": "spa"}
    bios.ModifyType2BaseboardInformation(type2_info)

    system_info = {
        'sn': "01234456",
        "uuid": 'u123456789012345',       # support uuid.UUID() object and string like 'E1A67716-9A01-403C-9A7A-B49F546DD342' as well
        'sku_number': '004900080060002D'
    }
    bios.ModifyType1SystemInformation(system_info)

    cpu = {"cores": 4,
           "version": "Intel(R) Xeon(R) Silver 4112 CPU @ 2.60GHz",
           "sn": "aaaaddd",
           "asset_tag": "asset_tag",
           "part_number": "part_number",
           "speed": 1800,
           "max_speed": 4000}
    bios.ModifyType4ProcessorInformation(cpu)

    dimm = [
        {"size": 8 * 1024 * 1024 * 1024,
         "manufactuer": "Hynix",
         "sn": "800{:03d}".format(random.randint(0, 1000)),
         "part_number": "HMA82GR7AFR8N-VK"},  # SLOT 0

        {},  # SLOT 1 is empty

        {"size": 8 * 1024 * 1024 * 1024,
         "manufactuer": "Hynix",
         "sn": "800{:03d}".format(random.randint(0, 1000)),
         "part_number": "HMA82GR7AFR8N-VK"},  # SLOT 2

        {},  # SLOT 3 is empty

        {"size": 8 * 1024 * 1024 * 1024,
         "manufactuer": "Hynix",
         "sn": "800{:03d}".format(random.randint(0, 1000)),
         "part_number": "HMA82GR7AFR8N-VK"},  # SLOT 4

         # other slots are all empty.
    ]
    bios.ModifyType17MemoryDevice(dimm)

    bios.save(filename + "2")
```
