### PR TITLE
Implement function to render smbios and emu data by yml.

### DIFF
--- a/infrasim/__init__.py
+++ b/infrasim/__init__.py
@@ -79,11 +79,26 @@ def has_option(config, *args):
     return True
 
 
+def set_option(_dict, *args):
+    # add dict value by cuple recursively.
+    # create key if it is not exist.
+    if len(args) < 2:
+        raise ArgsNotCorrect("set_option() need at least 1 key:value")
+    if len(args) == 2:
+        _dict[args[0]] = args[1]
+    else:
+        k = args[0]
+        args = args[1:]
+        if k not in _dict or not isinstance(_dict[k], dict):
+            _dict[k] = {}
+        set_option(_dict[k], *args)
+
+
 class InfraSimError(Exception):
     def __init__(self, value):
         self.value = value
         logger.exception("{}, stack:\n{}".format(self.value,
-                         str(inspect.stack()[1:]).replace("), (", "),\n(")))
+                                                 str(inspect.stack()[1:]).replace("), (", "),\n(")))
 
     def __str__(self):
         return repr(self.value)

--- a/infrasim/model/tasks/bmc.py
+++ b/infrasim/model/tasks/bmc.py
@@ -17,6 +17,7 @@ from infrasim import has_option, run_command
 from infrasim.helper import run_in_namespace
 from infrasim.model.core.task import Task
 from infrasim.log import infrasim_logdir
+from infrasim.chassis.emu_data import FruFile
 
 
 class CBMC(Task):
@@ -242,7 +243,7 @@ class CBMC(Task):
             path_resetcmd = os.path.join(self.get_workspace(),
                                          "scripts/resetcmd")
             path_setbootcmd = os.path.join(self.get_workspace(),
-                                         "scripts/setbootcmd")
+                                           "scripts/setbootcmd")
             path_bootdev = os.path.join(self.get_workspace(), "bootdev")
             path_qemu_pid = os.path.join(self.get_workspace(),
                                          ".{}-node.pid".format(self.__node_name))
@@ -377,8 +378,15 @@ class CBMC(Task):
             self.__emu_file = os.path.join(self.get_workspace(),
                                            "data/{}.emu".format(self.__vendor_type))
         else:
+            raise Exception("Should not here")
             self.__emu_file = os.path.join(config.infrasim_data,
                                            "{0}/{0}.emu".format(self.__vendor_type))
+        # render FRU information.
+        emu_file = FruFile(self.__emu_file)
+        emu_file.ChangeFruInfo(self.__bmc)
+        # update chassis pn/sn automaticlly.
+        emu_file.ChangeChassisInfo(self.__bmc.get('chassis_pn'), self.__bmc.get('chassis_sn'))
+        emu_file.Save(self.__emu_file, self.__bmc.get('merge_fru', True))
 
         if self.__node_name:
             self.__log_file = os.path.join(infrasim_logdir, self.__node_name, 'ipmi_sim.log')

--- a/infrasim/model/tasks/bmc.py
+++ b/infrasim/model/tasks/bmc.py
@@ -382,11 +382,12 @@ class CBMC(Task):
             self.__emu_file = os.path.join(config.infrasim_data,
                                            "{0}/{0}.emu".format(self.__vendor_type))
         # render FRU information.
-        emu_file = FruFile(self.__emu_file)
-        emu_file.ChangeFruInfo(self.__bmc)
-        # update chassis pn/sn automaticlly.
-        emu_file.ChangeChassisInfo(self.__bmc.get('chassis_pn'), self.__bmc.get('chassis_sn'))
-        emu_file.Save(self.__emu_file, self.__bmc.get('merge_fru', True))
+        if os.path.exists(self.__emu_file):
+            emu_file = FruFile(self.__emu_file)
+            emu_file.ChangeFruInfo(self.__bmc)
+            # update chassis pn/sn automaticlly.
+            emu_file.ChangeChassisInfo(self.__bmc.get('chassis_pn'), self.__bmc.get('chassis_sn'))
+            emu_file.Save(self.__emu_file, self.__bmc.get('merge_fru', True))
 
         if self.__node_name:
             self.__log_file = os.path.join(infrasim_logdir, self.__node_name, 'ipmi_sim.log')

--- a/infrasim/workspace.py
+++ b/infrasim/workspace.py
@@ -124,7 +124,7 @@ class Workspace(object):
         src = dst = os.path.join(path_data_dst, "{0}_smbios.bin".format(node_type))
         if has_option(self._info, "compute", "smbios", "file"):
             src = self._info["compute"]["smbios"]["file"]
-        elif has_option(self._info, "compute", "smbios"):
+        elif has_option(self._info, "compute", "smbios") and isinstance(self._info["compute"]["smbios"], str):
             # compatible with previous version.
             src = self._info["compute"]["smbios"]
         elif not os.path.exists(dst):

--- a/infrasim/workspace.py
+++ b/infrasim/workspace.py
@@ -4,7 +4,7 @@ import shutil
 from infrasim import config
 import subprocess
 from yaml_loader import YAMLLoader
-from . import has_option, InfraSimError
+from . import has_option, InfraSimError, set_option
 
 
 class Workspace(object):
@@ -105,35 +105,37 @@ class Workspace(object):
         if not os.path.exists(etc_path):
             os.mkdir(etc_path)
 
-        # IV. Save infrasim.yml
-        yml_file = os.path.join(self._workspace, "etc/infrasim.yml")
-        with open(yml_file, 'w') as fp:
-            yaml.dump(self._info, fp, default_flow_style=False)
-
         node_type = self._info["type"]
-        # V. Move emulation data
+        # IV. Move emulation data
         # Update identifier accordingly
         path_data_dst = os.path.join(self._workspace, "data")
+        src = dst = os.path.join(path_data_dst, "{0}.emu".format(node_type))
         if has_option(self._info, "bmc", "emu_file"):
-            if os.path.dirname(self._info["bmc"]["emu_file"]) != path_data_dst:
-                shutil.copy(self._info["bmc"]["emu_file"], path_data_dst)
-        elif not os.path.exists(os.path.join(path_data_dst, "{0}.emu".format(node_type))):
-            path_emu_src = os.path.join(config.infrasim_data, "{0}/{0}.emu".format(node_type))
-            shutil.copy(path_emu_src, os.path.join(path_data_dst, "{}.emu".
-                                                   format(node_type)))
+            src = self._info["bmc"]["emu_file"]
+        elif not os.path.exists(dst):
+            src = os.path.join(config.infrasim_data, "{0}/{0}.emu".format(node_type))
 
-        # VI. Move bios.bin
-        if has_option(self._info, "compute", "smbios"):
-            if os.path.dirname(self._info["compute"]["smbios"]) != path_data_dst:
-                shutil.copy(self._info["compute"]["smbios"], path_data_dst)
-        elif not os.path.exists(os.path.join(path_data_dst, "{0}_smbios.bin".format(node_type))):
-            path_bios_src = os.path.join(config.infrasim_data,
-                                         "{0}/{0}_smbios.bin".format(node_type))
-            shutil.copy(path_bios_src, os.path.join(path_data_dst,
-                                                    "{}_smbios.bin".
-                                                    format(node_type)))
+        if os.path.dirname(src) != path_data_dst:
+            shutil.copy(src, dst)
 
-        # VII. Move OEM data and script
+        set_option(self._info, "bmc", "emu_file", dst)
+
+        # V. Move bios.bin
+        src = dst = os.path.join(path_data_dst, "{0}_smbios.bin".format(node_type))
+        if has_option(self._info, "compute", "smbios", "file"):
+            src = self._info["compute"]["smbios"]["file"]
+        elif has_option(self._info, "compute", "smbios"):
+            # compatible with previous version.
+            src = self._info["compute"]["smbios"]
+        elif not os.path.exists(dst):
+            src = os.path.join(config.infrasim_data, "{0}/{0}_smbios.bin".format(node_type))
+
+        if os.path.dirname(src) != path_data_dst:
+            shutil.copy(src, dst)
+
+        set_option(self._info["compute"], "smbios", "file", dst)
+
+        # VI. Move OEM data and script
         path_oem_file_src = os.path.join(config.infrasim_data, "oem_data.json")
         path_oem_script_src = os.path.join(config.infrasim_scripts, "ipmi_exec.py")
         if os.path.exists(path_oem_file_src):
@@ -141,7 +143,10 @@ class Workspace(object):
         if os.path.exists(path_oem_script_src):
             shutil.copy(path_oem_script_src, os.path.join(script_path, "ipmi_exec.py"))
 
-        # Place holder to sync serial number
+        # VII. Save infrasim.yml
+        yml_file = os.path.join(self._workspace, "etc/infrasim.yml")
+        with open(yml_file, 'w') as fp:
+            yaml.dump(self._info, fp, default_flow_style=False)
 
     def terminate(self):
         """

--- a/test/unit/test_model.py
+++ b/test/unit/test_model.py
@@ -547,7 +547,7 @@ class qemu_functions(unittest.TestCase):
         compute.set_workspace("{}/{}".format(config.infrasim_home,
                                              node_info['name']))
         compute.init()
-        assert compute.get_smbios() == "/tmp/test.smbios"
+        assert compute.get_smbios() == os.path.join(compute.get_workspace(), "data/None_smbios.bin")
 
     def test_set_smbios_without_workspace(self):
         with open(config.infrasim_default_config, "r") as f_yml:


### PR DESCRIPTION
Usage in node:
```
node:
    bmc:
        emu_file: *******
        chassis_pn: ****  # automatic set chassis pn to all fru. Overwrite chassis pn in specific fru
        chassis_sn: ****   # automatic set chassis sn to all fru. Overwrite chassis sn in specific fru
        merge_fru: False
        fru2:
            chassis:
                pn:    *****   # set chassis sn to specific fru unit.    
                sn:
            board:
                pn:
                sn:
                name:
        fru27:
            chassis:
                pn:
                sn:
            board:
                pn:
                sn:
                name:
    compute:
        smbios:
            file: ********
            type1:  # system information
                sn:                 # could be overwritten by compute["serial_number"]
                uuid:             #  could be overwritten by compute["uuid"]
                sku_number:
            type2:  # base board informaiton
                sn:
                location:
            type3:  # chassis information
                sn:
            type4:  # processor information.
                cores:  4
                sn: 
            type17: # dimm information.
               -size: 8G  # slot 0.
                sn: *****
                pn: ****
               - # empty slot.
               -size: 8G
                sn: *****
                pn: ****
        
        # other setting.
```

Usage in chassis.yml
```
data:
    pn: "chassis_pn"  
    sn: "chassis_sn"  # 2 fields will be copied to each node automatically.
nodes:
   - <node A>
   - <node B>
```